### PR TITLE
Refactor IRegistryOptions

### DIFF
--- a/src/TextMateSharp.Demo/Program.cs
+++ b/src/TextMateSharp.Demo/Program.cs
@@ -200,7 +200,7 @@ namespace TextMateSharp
                     FileShare.ReadWrite);
             }
 
-            public IRawTheme GetTheme()
+            public IRawTheme GetCurrentTheme()
             {
                 int ini = Environment.TickCount;
                 

--- a/src/TextMateSharp.Demo/Program.cs
+++ b/src/TextMateSharp.Demo/Program.cs
@@ -121,47 +121,25 @@ namespace TextMateSharp
         {
             private string _grammarFile;
             private string _themeFile;
-            private IThemeResolver _themeResolver;
-            private IGrammarResolver _grammarResolver;
             internal DemoRegistryOptions(string grammarFile, string themeFile)
             {
                 _grammarFile = grammarFile;
                 _themeFile = themeFile;
-                _themeResolver = new DemoThemeResolver(GetFilePath);
-                _grammarResolver = new DemoGrammarResolver(GetFilePath);
             }
-            class DemoThemeResolver : IThemeResolver
-            {
-                private readonly Func<string, string> _getFilePathMethod;
 
-                public DemoThemeResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawTheme GetTheme(string scopeName)
-                {
-                    using var stream = new FileStream(_getFilePathMethod(scopeName), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    using var reader = new StreamReader(stream);
-                    return ThemeReader.ReadThemeSync(reader);
-                }
-            }
-            class DemoGrammarResolver : IGrammarResolver
+            public IRawTheme GetTheme(string scopeName)
             {
-                private readonly Func<string, string> _getFilePathMethod;
-
-                public DemoGrammarResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawGrammar GetGrammar(string scopeName)
-                {
-                    using var stream = new FileStream(_getFilePathMethod(scopeName), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    using var reader = new StreamReader(stream);
-                    return GrammarReader.ReadGrammarSync(reader);
-                }
+                using var stream = new FileStream(GetFilePath(scopeName), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                return ThemeReader.ReadThemeSync(reader);
             }
-            public IThemeResolver ThemeResolver { get => _themeResolver; set => _themeResolver = value; }
-            public IGrammarResolver GrammarResolver { get => _grammarResolver; set => _grammarResolver = value; }
+
+            public IRawGrammar GetGrammar(string scopeName)
+            {
+                using var stream = new FileStream(GetFilePath(scopeName), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                return GrammarReader.ReadGrammarSync(reader);
+            }
 
             private string GetFilePath(string scopeName)
             {
@@ -191,19 +169,10 @@ namespace TextMateSharp
                 return null;
             }
 
-            public Stream GetInputStream(string scopeName)
-            {
-                return new FileStream(
-                    GetFilePath(scopeName),
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite);
-            }
-
-            public IRawTheme GetCurrentTheme()
+            public IRawTheme GetDefaultTheme()
             {
                 int ini = Environment.TickCount;
-                
+
                 using (StreamReader reader = new StreamReader(_themeFile))
                 {
                     IRawTheme result = ThemeReader.ReadThemeSync(reader);

--- a/src/TextMateSharp.Tests/Internal/Grammars/GrammarTests.cs
+++ b/src/TextMateSharp.Tests/Internal/Grammars/GrammarTests.cs
@@ -280,48 +280,18 @@ namespace TextMateSharp.Tests.Internal.Grammars
 
         class TestRegistry : IRegistryOptions
         {
-            private IThemeResolver _themeResolver;
-            private IGrammarResolver _grammarResolver;
-            public TestRegistry()
+            public IRawTheme GetTheme(string scopeName)
             {
-                _themeResolver = new DemoThemeResolver(GetFilePath);
-                _grammarResolver = new DemoGrammarResolver(GetFilePath);
+                using var stream = ResourceReader.OpenStream(GetFilePath(scopeName));
+                using var reader = new StreamReader(stream);
+                return ThemeReader.ReadThemeSync(reader);
             }
-            public IThemeResolver ThemeResolver { get => _themeResolver; set => _themeResolver = value; }
-            public IGrammarResolver GrammarResolver { get => _grammarResolver; set => _grammarResolver = value; }
-            class DemoThemeResolver : IThemeResolver
-            {
-                private readonly Func<string, string> _getFilePathMethod;
 
-                public DemoThemeResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawTheme GetTheme(string scopeName)
-                {
-                    using var stream = ResourceReader.OpenStream(_getFilePathMethod(scopeName));
-                    using var reader = new StreamReader(stream);
-                    return ThemeReader.ReadThemeSync(reader);
-                }
-            }
-            class DemoGrammarResolver : IGrammarResolver
+            public IRawGrammar GetGrammar(string scopeName)
             {
-                private readonly Func<string, string> _getFilePathMethod;
-
-                public DemoGrammarResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawGrammar GetGrammar(string scopeName)
-                {
-                    using var stream = ResourceReader.OpenStream(_getFilePathMethod(scopeName));
-                    using var reader = new StreamReader(stream);
-                    return GrammarReader.ReadGrammarSync(reader);
-                }
-            }
-            Stream GetInputStream(string scopeName)
-            {
-                return ResourceReader.OpenStream(GetFilePath(scopeName));
+                using var stream = ResourceReader.OpenStream(GetFilePath(scopeName));
+                using var reader = new StreamReader(stream);
+                return GrammarReader.ReadGrammarSync(reader);
             }
 
             ICollection<string> IRegistryOptions.GetInjections(string scopeName)
@@ -366,7 +336,7 @@ namespace TextMateSharp.Tests.Internal.Grammars
                 return null;
             }
 
-            IRawTheme IRegistryOptions.GetCurrentTheme()
+            IRawTheme IRegistryOptions.GetDefaultTheme()
             {
                 using (Stream stream = ResourceReader.OpenStream("dark_vs.json"))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/TextMateSharp.Tests/Internal/Themes/Reader/ThemeReaderTests.cs
+++ b/src/TextMateSharp.Tests/Internal/Themes/Reader/ThemeReaderTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
-
-using NUnit.Framework;
 using TextMateSharp.Internal.Grammars.Reader;
 using TextMateSharp.Internal.Themes.Reader;
 using TextMateSharp.Internal.Types;
@@ -36,52 +34,30 @@ namespace TextMateSharp.Tests.Internal.Themes.Reader
         class TestRegistry : IRegistryOptions
         {
             private string _theme;
-            private IThemeResolver _themeResolver;
-            private IGrammarResolver _grammarResolver;
-            public IThemeResolver ThemeResolver { get => _themeResolver; set => _themeResolver = value; }
-            public IGrammarResolver GrammarResolver { get => _grammarResolver; set => _grammarResolver = value; }
 
             internal TestRegistry(string theme)
             {
                 _theme = theme;
-                _themeResolver = new DemoThemeResolver(GetFilePath);
-                _grammarResolver = new DemoGrammarResolver(GetFilePath);
             }
-            class DemoThemeResolver : IThemeResolver
+            public IRawTheme GetTheme(string scopeName)
             {
-                private readonly Func<string, string> _getFilePathMethod;
+                if (scopeName.StartsWith("./"))
+                    scopeName = scopeName.Replace("./", string.Empty);
 
-                public DemoThemeResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawTheme GetTheme(string scopeName)
-                {
-                    if (scopeName.StartsWith("./"))
-                        scopeName = scopeName.Replace("./", string.Empty);
-
-                    using var stream = ResourceReader.OpenStream(_getFilePathMethod(scopeName));
-                    using var reader = new StreamReader(stream);
-                    return ThemeReader.ReadThemeSync(reader);
-                }
+                using var stream = ResourceReader.OpenStream(GetFilePath(scopeName));
+                using var reader = new StreamReader(stream);
+                return ThemeReader.ReadThemeSync(reader);
             }
-            class DemoGrammarResolver : IGrammarResolver
+
+
+            public IRawGrammar GetGrammar(string scopeName)
             {
-                private readonly Func<string, string> _getFilePathMethod;
+                if (scopeName.StartsWith("./"))
+                    scopeName = scopeName.Replace("./", string.Empty);
 
-                public DemoGrammarResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawGrammar GetGrammar(string scopeName)
-                {
-                    if (scopeName.StartsWith("./"))
-                        scopeName = scopeName.Replace("./", string.Empty);
-
-                    using var stream = ResourceReader.OpenStream(_getFilePathMethod(scopeName));
-                    using var reader = new StreamReader(stream);
-                    return GrammarReader.ReadGrammarSync(reader);
-                }
+                using var stream = ResourceReader.OpenStream(GetFilePath(scopeName));
+                using var reader = new StreamReader(stream);
+                return GrammarReader.ReadGrammarSync(reader);
             }
 
             ICollection<string> IRegistryOptions.GetInjections(string scopeName)
@@ -94,7 +70,7 @@ namespace TextMateSharp.Tests.Internal.Themes.Reader
                 return scopeName;
             }
 
-            IRawTheme IRegistryOptions.GetCurrentTheme()
+            IRawTheme IRegistryOptions.GetDefaultTheme()
             {
                 using (Stream stream = ResourceReader.OpenStream(_theme))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/TextMateSharp.Tests/Internal/Themes/ThemeTest.cs
+++ b/src/TextMateSharp.Tests/Internal/Themes/ThemeTest.cs
@@ -1,11 +1,6 @@
-﻿using System;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using NUnit.Framework;
 using TextMateSharp.Internal.Grammars.Reader;
 using TextMateSharp.Internal.Themes.Reader;
 using TextMateSharp.Internal.Types;
@@ -23,7 +18,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[] { "keyword.control" });
@@ -39,7 +34,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -52,14 +47,14 @@ namespace TextMateSharp.Tests.Internal.Themes
                 "#C586C0",
                 theme.GetColor(rules[0].foreground));
         }
-        
+
         [Test]
         public void PHPVariableTest()
         {
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -79,7 +74,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -99,7 +94,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -122,7 +117,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -146,7 +141,7 @@ namespace TextMateSharp.Tests.Internal.Themes
             IRegistryOptions registryOptions = new TestRegistry();
 
             Theme theme = Theme.CreateFromRawTheme(
-                registryOptions.GetCurrentTheme(),
+                registryOptions.GetDefaultTheme(),
                 registryOptions);
 
             var rules = theme.Match(new string[]
@@ -164,50 +159,24 @@ namespace TextMateSharp.Tests.Internal.Themes
 
         class TestRegistry : IRegistryOptions
         {
-            private IThemeResolver _themeResolver;
-            private IGrammarResolver _grammarResolver;
-            public TestRegistry()
+            public IRawTheme GetTheme(string scopeName)
             {
-                _themeResolver = new DemoThemeResolver(GetFilePath);
-                _grammarResolver = new DemoGrammarResolver(GetFilePath);
+                if (scopeName == "./dark_vs.json")
+                    scopeName = "dark_vs.json";
+
+                using var stream = ResourceReader.OpenStream(scopeName);
+                using var reader = new StreamReader(stream);
+                return ThemeReader.ReadThemeSync(reader);
             }
-            public IThemeResolver ThemeResolver { get => _themeResolver; set => _themeResolver = value; }
-            public IGrammarResolver GrammarResolver { get => _grammarResolver; set => _grammarResolver = value; }
-            class DemoThemeResolver : IThemeResolver
+
+            public IRawGrammar GetGrammar(string scopeName)
             {
-                private readonly Func<string, string> _getFilePathMethod;
+                if (scopeName == "./dark_vs.json")
+                    scopeName = "dark_vs.json";
 
-                public DemoThemeResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawTheme GetTheme(string scopeName)
-                {
-                    if (scopeName == "./dark_vs.json")
-                        scopeName = "dark_vs.json";
-
-                    using var stream = ResourceReader.OpenStream(scopeName);
-                    using var reader = new StreamReader(stream);
-                    return ThemeReader.ReadThemeSync(reader);
-                }
-            }
-            class DemoGrammarResolver : IGrammarResolver
-            {
-                private readonly Func<string, string> _getFilePathMethod;
-
-                public DemoGrammarResolver(Func<string, string> getFilePathMethod)
-                {
-                    this._getFilePathMethod = getFilePathMethod;
-                }
-                public IRawGrammar GetGrammar(string scopeName)
-                {
-                    if (scopeName == "./dark_vs.json")
-                        scopeName = "dark_vs.json";
-
-                    using var stream = ResourceReader.OpenStream(scopeName);
-                    using var reader = new StreamReader(stream);
-                    return GrammarReader.ReadGrammarSync(reader);
-                }
+                using var stream = ResourceReader.OpenStream(scopeName);
+                using var reader = new StreamReader(stream);
+                return GrammarReader.ReadGrammarSync(reader);
             }
 
             ICollection<string> IRegistryOptions.GetInjections(string scopeName)
@@ -215,12 +184,7 @@ namespace TextMateSharp.Tests.Internal.Themes
                 return null;
             }
 
-            string GetFilePath(string scopeName)
-            {
-                return string.Empty;
-            }
-
-            IRawTheme IRegistryOptions.GetCurrentTheme()
+            IRawTheme IRegistryOptions.GetDefaultTheme()
             {
                 using (Stream stream = ResourceReader.OpenStream("dark_plus.json"))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/TextMateSharp/Registry/IRegistryOptions.cs
+++ b/src/TextMateSharp/Registry/IRegistryOptions.cs
@@ -10,7 +10,7 @@ namespace TextMateSharp.Registry
         public IThemeResolver ThemeResolver { get; set; }
         public IGrammarResolver GrammarResolver { get; set; }
         ICollection<string> GetInjections(string scopeName);
-        IRawTheme GetTheme();
+        IRawTheme GetCurrentTheme();
     }
 
     public interface IThemeResolver
@@ -42,7 +42,7 @@ namespace TextMateSharp.Registry
             return null;
         }
 
-        public IRawTheme GetTheme()
+        public IRawTheme GetCurrentTheme()
         {
             return null;
         }

--- a/src/TextMateSharp/Registry/IRegistryOptions.cs
+++ b/src/TextMateSharp/Registry/IRegistryOptions.cs
@@ -1,23 +1,32 @@
 using System.Collections.Generic;
 using System.IO;
-
+using TextMateSharp.Internal.Types;
 using TextMateSharp.Themes;
 
 namespace TextMateSharp.Registry
 {
     public interface IRegistryOptions
     {
-        string GetFilePath(string scopeName);
-
-        Stream GetInputStream(string scopeName);
-
+        public IThemeResolver ThemeResolver { get; set; }
+        public IGrammarResolver GrammarResolver { get; set; }
         ICollection<string> GetInjections(string scopeName);
-
         IRawTheme GetTheme();
     }
 
+    public interface IThemeResolver
+    {
+        IRawTheme GetTheme(string scopeName);
+    }
+    public interface IGrammarResolver
+    {
+        IRawGrammar GetGrammar(string scopeName);
+
+    }
     public class DefaultLocator : IRegistryOptions
     {
+        public IThemeResolver ThemeResolver { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public IGrammarResolver GrammarResolver { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
         public string GetFilePath(string scopeName)
         {
             return null;

--- a/src/TextMateSharp/Registry/IRegistryOptions.cs
+++ b/src/TextMateSharp/Registry/IRegistryOptions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using TextMateSharp.Internal.Types;
 using TextMateSharp.Themes;
 
@@ -7,10 +6,10 @@ namespace TextMateSharp.Registry
 {
     public interface IRegistryOptions
     {
-        public IThemeResolver ThemeResolver { get; set; }
-        public IGrammarResolver GrammarResolver { get; set; }
+        IRawTheme GetTheme(string scopeName);
+        IRawGrammar GetGrammar(string scopeName);
         ICollection<string> GetInjections(string scopeName);
-        IRawTheme GetCurrentTheme();
+        IRawTheme GetDefaultTheme();
     }
 
     public interface IThemeResolver
@@ -24,25 +23,22 @@ namespace TextMateSharp.Registry
     }
     public class DefaultLocator : IRegistryOptions
     {
-        public IThemeResolver ThemeResolver { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-        public IGrammarResolver GrammarResolver { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-
-        public string GetFilePath(string scopeName)
-        {
-            return null;
-        }
-
         public ICollection<string> GetInjections(string scopeName)
         {
             return null;
         }
 
-        public Stream GetInputStream(string scopeName)
+        public IRawTheme GetDefaultTheme()
         {
             return null;
         }
 
-        public IRawTheme GetCurrentTheme()
+        public IRawTheme GetTheme(string scopeName)
+        {
+            return null;
+        }
+
+        public IRawGrammar GetGrammar(string scopeName)
         {
             return null;
         }

--- a/src/TextMateSharp/Registry/Registry.cs
+++ b/src/TextMateSharp/Registry/Registry.cs
@@ -27,7 +27,7 @@ namespace TextMateSharp.Registry
             this.locator = locator;
             this.syncRegistry = new SyncRegistry(
                 TmTheme.CreateFromRawTheme(
-                    locator.GetTheme(), locator));
+                    locator.GetCurrentTheme(), locator));
         }
 
         public void SetTheme(IRawTheme theme)

--- a/src/TextMateSharp/Registry/Registry.cs
+++ b/src/TextMateSharp/Registry/Registry.cs
@@ -60,30 +60,9 @@ namespace TextMateSharp.Registry
                     continue;
                 }
 
-                string filePath = this.locator.GetFilePath(scopeName);
-                if (filePath == null)
-                {
-                    if (scopeName.Equals(initialScopeName))
-                    {
-                        throw new TMException("Unknown location for grammar <" + initialScopeName + ">");
-                    }
-                    continue;
-                }
-
                 try
                 {
-                    IRawGrammar grammar = null;
-
-                    Stream stream = this.locator.GetInputStream(scopeName);
-
-                    if (stream != null)
-                    {
-                        using (stream)
-                        using (StreamReader reader = new StreamReader(stream))
-                        {
-                            grammar = GrammarReader.ReadGrammarSync(reader);
-                        }
-                    }
+                    IRawGrammar grammar = this.locator.GrammarResolver.GetGrammar(scopeName);
 
                     if (grammar == null)
                         continue;

--- a/src/TextMateSharp/Registry/Registry.cs
+++ b/src/TextMateSharp/Registry/Registry.cs
@@ -27,7 +27,7 @@ namespace TextMateSharp.Registry
             this.locator = locator;
             this.syncRegistry = new SyncRegistry(
                 TmTheme.CreateFromRawTheme(
-                    locator.GetCurrentTheme(), locator));
+                    locator.GetDefaultTheme(), locator));
         }
 
         public void SetTheme(IRawTheme theme)
@@ -62,7 +62,7 @@ namespace TextMateSharp.Registry
 
                 try
                 {
-                    IRawGrammar grammar = this.locator.GrammarResolver.GetGrammar(scopeName);
+                    IRawGrammar grammar = this.locator.GetGrammar(scopeName);
 
                     if (grammar == null)
                         continue;

--- a/src/TextMateSharp/TextMateSharp.csproj
+++ b/src/TextMateSharp/TextMateSharp.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	<LangVersion>8.0</LangVersion>
     <Description>An interpreter for grammar files as defined by TextMate. TextMate grammars use the oniguruma dialect (https://github.com/kkos/oniguruma). Supports loading grammar files only from JSON format. Cross - grammar injections are currently not supported.
 
 TextMateSharp is a port of microsoft/vscode-textmate that brings TextMate grammars to dotnet ecosystem. The implementation is based the Java port eclipse/tm4e.

--- a/src/TextMateSharp/Themes/Theme.cs
+++ b/src/TextMateSharp/Themes/Theme.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
-
 using TextMateSharp.Internal.Utils;
 using TextMateSharp.Registry;
-using TextMateSharp.Internal.Themes.Reader;
-using System.IO;
 
 namespace TextMateSharp.Themes
 {
@@ -44,7 +41,7 @@ namespace TextMateSharp.Themes
         {
             List<ThemeTrieElementRule> result = new List<ThemeTrieElementRule>();
 
-            for(int i=scopeNames.Count -1; i>=0; i--)
+            for (int i = scopeNames.Count - 1; i >= 0; i--)
                 result.AddRange(this._theme.Match(scopeNames[i]));
 
             for (int i = scopeNames.Count - 1; i >= 0; i--)
@@ -113,21 +110,13 @@ namespace TextMateSharp.Themes
             if (string.IsNullOrEmpty(include))
                 return result;
 
-            Stream stream = registryOptions.GetInputStream(include);
+            IRawTheme themeInclude = registryOptions.ThemeResolver.GetTheme(include);
 
-            if (stream == null)
+            if (themeInclude == null)
                 return result;
 
-            using (stream)
-            using (StreamReader reader = new StreamReader(stream))
-            {
-                IRawTheme themeInclude = ThemeReader.ReadThemeSync(reader);
+            return ParseTheme(themeInclude, priority);
 
-                if (themeInclude == null)
-                    return result;
-
-                return ParseTheme(themeInclude, priority);
-            }
         }
 
         static void LookupThemeRules(
@@ -152,7 +141,7 @@ namespace TextMateSharp.Themes
                 {
                     string scope = (string)settingScope;
 
-                    scopes = new List<string>(scope.Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries));
+                    scopes = new List<string>(scope.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries));
                 }
                 else if (settingScope is IList<object>)
                 {
@@ -169,7 +158,7 @@ namespace TextMateSharp.Themes
                 {
                     fontStyle = FontStyle.None;
 
-                    string[] segments = ((string) settingsFontStyle).Split(new[] {" "}, StringSplitOptions.None);
+                    string[] segments = ((string)settingsFontStyle).Split(new[] { " " }, StringSplitOptions.None);
                     foreach (string segment in segments)
                     {
                         if ("italic".Equals(segment))
@@ -204,7 +193,7 @@ namespace TextMateSharp.Themes
                 {
                     string _scope = scopes[j].Trim();
 
-                    List<string> segments = new List<string>(_scope.Split(new[] {" "}, StringSplitOptions.None));
+                    List<string> segments = new List<string>(_scope.Split(new[] { " " }, StringSplitOptions.None));
 
                     string scope = segments[segments.Count - 1];
                     List<string> parentScopes = null;

--- a/src/TextMateSharp/Themes/Theme.cs
+++ b/src/TextMateSharp/Themes/Theme.cs
@@ -110,7 +110,7 @@ namespace TextMateSharp.Themes
             if (string.IsNullOrEmpty(include))
                 return result;
 
-            IRawTheme themeInclude = registryOptions.ThemeResolver.GetTheme(include);
+            IRawTheme themeInclude = registryOptions.GetTheme(include);
 
             if (themeInclude == null)
                 return result;


### PR DESCRIPTION
This refactoring allows us to implement more flexible IRegistryOptions, it allows us to use this library for example in WASM because we don't rely anymore on file paths. Reduces overhead of GetInputStream method, now there is no overhead basically.