### PR TITLE
Tidy code

### DIFF
--- a/src/TextMateSharp.Tests/Internal/Oniguruma/OnigScannerTests.cs
+++ b/src/TextMateSharp.Tests/Internal/Oniguruma/OnigScannerTests.cs
@@ -16,10 +16,10 @@ namespace TextMateSharp.Tests.Internal.Oniguruma
 
             Assert.AreEqual(2, captureIndices.Length);
 
-            Assert.AreEqual(0, captureIndices[0].GetStart());
-            Assert.AreEqual(2, captureIndices[0].GetLength());
-            Assert.AreEqual(1, captureIndices[1].GetStart());
-            Assert.AreEqual(1, captureIndices[1].GetLength());
+            Assert.AreEqual(0, captureIndices[0].Start);
+            Assert.AreEqual(2, captureIndices[0].Length);
+            Assert.AreEqual(1, captureIndices[1].Start);
+            Assert.AreEqual(1, captureIndices[1].Length);
         }
 
         [Test]
@@ -32,10 +32,10 @@ namespace TextMateSharp.Tests.Internal.Oniguruma
 
             Assert.AreEqual(2, captureIndices.Length);
 
-            Assert.AreEqual(1, captureIndices[0].GetStart());
-            Assert.AreEqual(3, captureIndices[0].GetLength());
-            Assert.AreEqual(2, captureIndices[1].GetStart());
-            Assert.AreEqual(1, captureIndices[1].GetLength());
+            Assert.AreEqual(1, captureIndices[0].Start);
+            Assert.AreEqual(3, captureIndices[0].Length);
+            Assert.AreEqual(2, captureIndices[1].Start);
+            Assert.AreEqual(1, captureIndices[1].Length);
         }
 
         [Test]
@@ -72,8 +72,8 @@ namespace TextMateSharp.Tests.Internal.Oniguruma
             int index)
         {
             return text.Substring(
-                captures[index].GetStart(),
-                captures[index].GetLength());
+                captures[index].Start,
+                captures[index].Length);
         }
     }
 }

--- a/src/TextMateSharp/Grammar/ITokenizeLineResult2.cs
+++ b/src/TextMateSharp/Grammar/ITokenizeLineResult2.cs
@@ -2,7 +2,7 @@ namespace TextMateSharp.Grammars
 {
     public interface ITokenizeLineResult2
     {
-        int[] GetTokens();
-        StackElement GetRuleStack();
+        int[] Tokens { get; }
+        StackElement RuleStack { get; }
     }
 }

--- a/src/TextMateSharp/Grammar/Injection.cs
+++ b/src/TextMateSharp/Grammar/Injection.cs
@@ -7,23 +7,24 @@ namespace TextMateSharp.Grammars
 {
     public class Injection
     {
+        public int Priority { get; private set; } // -1 | 0 | 1; // 0 is the default. -1 for 'L' and 1 for 'R'
+        public int? RuleId { get; private set; }
+        public IRawGrammar Grammar { get; private set; }
 
-        private Predicate<List<string>> matcher;
-        public int priority; // -1 | 0 | 1; // 0 is the default. -1 for 'L' and 1 for 'R'
-        public int? ruleId;
-        public IRawGrammar grammar;
+        private Predicate<List<string>> _matcher;
 
         public Injection(Predicate<List<string>> matcher, int? ruleId, IRawGrammar grammar, int priority)
         {
-            this.matcher = matcher;
-            this.ruleId = ruleId;
-            this.grammar = grammar;
-            this.priority = priority;
+            RuleId = ruleId;
+            Grammar = grammar;
+            Priority = priority;
+
+            this._matcher = matcher;
         }
 
         public bool Match(List<string> states)
         {
-            return matcher.Invoke(states);
+            return _matcher.Invoke(states);
         }
     }
 }

--- a/src/TextMateSharp/Grammar/StackElement.cs
+++ b/src/TextMateSharp/Grammar/StackElement.cs
@@ -10,13 +10,14 @@ namespace TextMateSharp.Grammars
     {
         public static StackElement NULL = new StackElement(null, 0, 0, null, null, null);
 
-        private int enterPosition;
-        public StackElement parent;
-        public int depth;
-        public int? ruleId;
-        public string endRule;
-        public ScopeListElement nameScopesList;
-        public ScopeListElement contentNameScopesList;
+        public StackElement Parent { get; private set; }
+        public int Depth { get; private set; }
+        public int? RuleId { get; private set; }
+        public string EndRule { get; private set; }
+        public ScopeListElement NameScopesList { get; private set; }
+        public ScopeListElement ContentNameScopesList { get; private set; }
+
+        private int _enterPosition;
 
         public StackElement(
             StackElement parent,
@@ -26,13 +27,14 @@ namespace TextMateSharp.Grammars
             ScopeListElement nameScopesList,
             ScopeListElement contentNameScopesList)
         {
-            this.parent = parent;
-            this.depth = (this.parent != null ? this.parent.depth + 1 : 1);
-            this.ruleId = ruleId;
-            this.enterPosition = enterPos;
-            this.endRule = endRule;
-            this.nameScopesList = nameScopesList;
-            this.contentNameScopesList = contentNameScopesList;
+            Parent = parent;
+            Depth = (this.Parent != null ? this.Parent.Depth + 1 : 1);
+            RuleId = ruleId;
+            EndRule = endRule;
+            NameScopesList = nameScopesList;
+            ContentNameScopesList = contentNameScopesList;
+
+            _enterPosition = enterPos;
         }
 
         private static bool StructuralEquals(StackElement a, StackElement b)
@@ -45,7 +47,7 @@ namespace TextMateSharp.Grammars
             {
                 return false;
             }
-            return a.depth == b.depth && a.ruleId == b.ruleId && Equals(a.endRule, b.endRule) && StructuralEquals(a.parent, b.parent);
+            return a.Depth == b.Depth && a.RuleId == b.RuleId && Equals(a.EndRule, b.EndRule) && StructuralEquals(a.Parent, b.Parent);
         }
 
         public override bool Equals(Object other)
@@ -62,16 +64,16 @@ namespace TextMateSharp.Grammars
                 return false;
             }
             StackElement stackElement = (StackElement)other;
-            return StructuralEquals(this, stackElement) && this.contentNameScopesList.Equals(stackElement.contentNameScopesList);
+            return StructuralEquals(this, stackElement) && this.ContentNameScopesList.Equals(stackElement.ContentNameScopesList);
         }
 
         public override int GetHashCode()
         {
-            return depth.GetHashCode() + 
-                ruleId.GetHashCode() +
-                endRule.GetHashCode() + 
-                parent.GetHashCode() +
-                contentNameScopesList.GetHashCode();
+            return Depth.GetHashCode() + 
+                RuleId.GetHashCode() +
+                EndRule.GetHashCode() + 
+                Parent.GetHashCode() +
+                ContentNameScopesList.GetHashCode();
         }
 
         public void Reset()
@@ -79,21 +81,21 @@ namespace TextMateSharp.Grammars
             StackElement el = this;
             while (el != null)
             {
-                el.enterPosition = -1;
-                el = el.parent;
+                el._enterPosition = -1;
+                el = el.Parent;
             }
         }
 
         public StackElement Pop()
         {
-            return this.parent;
+            return this.Parent;
         }
 
         public StackElement SafePop()
         {
-            if (this.parent != null)
+            if (this.Parent != null)
             {
-                return this.parent;
+                return this.Parent;
             }
             return this;
         }
@@ -105,22 +107,22 @@ namespace TextMateSharp.Grammars
 
         public int GetEnterPos()
         {
-            return this.enterPosition;
+            return this._enterPosition;
         }
 
         public Rule GetRule(IRuleRegistry grammar)
         {
-            return grammar.GetRule(this.ruleId);
+            return grammar.GetRule(this.RuleId);
         }
 
         private void AppendString(List<string> res)
         {
-            if (this.parent != null)
+            if (this.Parent != null)
             {
-                this.parent.AppendString(res);
+                this.Parent.AppendString(res);
             }
 
-            res.Add('(' + this.ruleId.ToString() + ')'); //, TODO-${this.nameScopesList}, TODO-${this.contentNameScopesList})`;
+            res.Add('(' + this.RuleId.ToString() + ')'); //, TODO-${this.nameScopesList}, TODO-${this.contentNameScopesList})`;
         }
 
         public override string ToString()
@@ -132,25 +134,25 @@ namespace TextMateSharp.Grammars
 
         public StackElement setContentNameScopesList(ScopeListElement contentNameScopesList)
         {
-            if (this.contentNameScopesList.Equals(contentNameScopesList))
+            if (this.ContentNameScopesList.Equals(contentNameScopesList))
             {
                 return this;
             }
-            return this.parent.Push(this.ruleId, this.enterPosition, this.endRule, this.nameScopesList, contentNameScopesList);
+            return this.Parent.Push(this.RuleId, this._enterPosition, this.EndRule, this.NameScopesList, contentNameScopesList);
         }
 
         public StackElement SetEndRule(string endRule)
         {
-            if (this.endRule != null && this.endRule.Equals(endRule))
+            if (this.EndRule != null && this.EndRule.Equals(endRule))
             {
                 return this;
             }
-            return new StackElement(this.parent, this.ruleId, this.enterPosition, endRule, this.nameScopesList, this.contentNameScopesList);
+            return new StackElement(this.Parent, this.RuleId, this._enterPosition, endRule, this.NameScopesList, this.ContentNameScopesList);
         }
 
         public bool HasSameRuleAs(StackElement other)
         {
-            return this.ruleId == other.ruleId;
+            return this.RuleId == other.RuleId;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Grammars/LineTokens.cs
+++ b/src/TextMateSharp/Internal/Grammars/LineTokens.cs
@@ -8,89 +8,87 @@ namespace TextMateSharp.Internal.Grammars
 {
     internal class LineTokens
     {
-
-        private string lineText;
+        private string _lineText;
 
         // used only if `_emitBinaryTokens` is false.
-        private List<IToken> tokens;
+        private List<IToken> _tokens;
 
-
-        private bool emitBinaryTokens;
+        private bool _emitBinaryTokens;
 
         // used only if `_emitBinaryTokens` is true.
         private List<int> binaryTokens;
 
-        private int lastTokenEndIndex;
+        private int _lastTokenEndIndex;
 
         internal LineTokens(bool emitBinaryTokens, string lineText)
         {
-            this.emitBinaryTokens = emitBinaryTokens;
-            this.lineText = lineText;
-            if (this.emitBinaryTokens)
+            this._emitBinaryTokens = emitBinaryTokens;
+            this._lineText = lineText;
+            if (this._emitBinaryTokens)
             {
-                this.tokens = null;
+                this._tokens = null;
                 this.binaryTokens = new List<int>();
             }
             else
             {
-                this.tokens = new List<IToken>();
+                this._tokens = new List<IToken>();
                 this.binaryTokens = null;
             }
-            this.lastTokenEndIndex = 0;
+            this._lastTokenEndIndex = 0;
         }
 
         public void Produce(StackElement stack, int endIndex)
         {
-            this.ProduceFromScopes(stack.contentNameScopesList, endIndex);
+            this.ProduceFromScopes(stack.ContentNameScopesList, endIndex);
         }
 
         public void ProduceFromScopes(ScopeListElement scopesList, int endIndex)
         {
-            if (this.lastTokenEndIndex >= endIndex)
+            if (this._lastTokenEndIndex >= endIndex)
             {
                 return;
             }
 
-            if (this.emitBinaryTokens)
+            if (this._emitBinaryTokens)
             {
-                int metadata = scopesList.metadata;
+                int metadata = scopesList.Metadata;
                 if (this.binaryTokens.Count != 0 && this.binaryTokens[this.binaryTokens.Count - 1] == metadata)
                 {
                     // no need to push a token with the same metadata
-                    this.lastTokenEndIndex = endIndex;
+                    this._lastTokenEndIndex = endIndex;
                     return;
                 }
 
-                this.binaryTokens.Add(this.lastTokenEndIndex);
+                this.binaryTokens.Add(this._lastTokenEndIndex);
                 this.binaryTokens.Add(metadata);
 
-                this.lastTokenEndIndex = endIndex;
+                this._lastTokenEndIndex = endIndex;
                 return;
             }
 
             List<string> scopes = scopesList.GenerateScopes();
 
-            this.tokens.Add(new Token(this.lastTokenEndIndex, endIndex, scopes));
-            this.lastTokenEndIndex = endIndex;
+            this._tokens.Add(new Token(this._lastTokenEndIndex, endIndex, scopes));
+            this._lastTokenEndIndex = endIndex;
         }
 
 
         public IToken[] GetResult(StackElement stack, int lineLength)
         {
-            if (this.tokens.Count != 0 && this.tokens[this.tokens.Count - 1].StartIndex == lineLength - 1)
+            if (this._tokens.Count != 0 && this._tokens[this._tokens.Count - 1].StartIndex == lineLength - 1)
             {
                 // pop produced token for newline
-                this.tokens.RemoveAt(this.tokens.Count - 1);
+                this._tokens.RemoveAt(this._tokens.Count - 1);
             }
 
-            if (this.tokens.Count == 0)
+            if (this._tokens.Count == 0)
             {
-                this.lastTokenEndIndex = -1;
+                this._lastTokenEndIndex = -1;
                 this.Produce(stack, lineLength);
-                this.tokens[this.tokens.Count - 1].StartIndex = 0;
+                this._tokens[this._tokens.Count - 1].StartIndex = 0;
             }
 
-            return this.tokens.ToArray();
+            return this._tokens.ToArray();
         }
 
         public int[] GetBinaryResult(StackElement stack, int lineLength)
@@ -104,7 +102,7 @@ namespace TextMateSharp.Internal.Grammars
 
             if (this.binaryTokens.Count == 0)
             {
-                this.lastTokenEndIndex = -1;
+                this._lastTokenEndIndex = -1;
                 this.Produce(stack, lineLength);
                 this.binaryTokens[this.binaryTokens.Count - 2] = 0;
             }

--- a/src/TextMateSharp/Internal/Grammars/LocalStackElement.cs
+++ b/src/TextMateSharp/Internal/Grammars/LocalStackElement.cs
@@ -2,23 +2,13 @@ namespace TextMateSharp.Internal.Grammars
 {
     class LocalStackElement
     {
-        private ScopeListElement scopes;
-        private int endPos;
+        public ScopeListElement Scopes { get; private set; }
+        public int EndPos { get; private set; }
 
         public LocalStackElement(ScopeListElement scopes, int endPos)
         {
-            this.scopes = scopes;
-            this.endPos = endPos;
-        }
-
-        public ScopeListElement GetScopes()
-        {
-            return scopes;
-        }
-
-        public int GetEndPos()
-        {
-            return endPos;
+            Scopes = scopes;
+            EndPos = endPos;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Grammars/ScopeListElement.cs
+++ b/src/TextMateSharp/Internal/Grammars/ScopeListElement.cs
@@ -7,16 +7,15 @@ namespace TextMateSharp.Internal.Grammars
 {
     public class ScopeListElement
     {
-
-        public ScopeListElement parent;
-        public string scope;
-        public int metadata;
+        public ScopeListElement Parent { get; private set; }
+        public string Scope { get; private set; }
+        public int Metadata { get; private set; }
 
         public ScopeListElement(ScopeListElement parent, string scope, int metadata)
         {
-            this.parent = parent;
-            this.scope = scope;
-            this.metadata = metadata;
+            Parent = parent;
+            Scope = scope;
+            Metadata = metadata;
         }
 
         private static bool Equals(ScopeListElement a, ScopeListElement b)
@@ -29,7 +28,7 @@ namespace TextMateSharp.Internal.Grammars
             {
                 return false;
             }
-            return Object.Equals(a.scope, b.scope) && a.metadata == b.metadata && Equals(a.parent, b.parent);
+            return Object.Equals(a.Scope, b.Scope) && a.Metadata == b.Metadata && Equals(a.Parent, b.Parent);
         }
 
         public override bool Equals(object other)
@@ -51,9 +50,9 @@ namespace TextMateSharp.Internal.Grammars
 
         public override int GetHashCode()
         {
-            return scope.GetHashCode() +
-                    metadata.GetHashCode() +
-                parent.GetHashCode();
+            return Scope.GetHashCode() +
+                    Metadata.GetHashCode() +
+                Parent.GetHashCode();
         }
 
 
@@ -76,7 +75,7 @@ namespace TextMateSharp.Internal.Grammars
 
             while (target != null)
             {
-                if (MatchesScope(target.scope, selector, selectorWithDot))
+                if (MatchesScope(target.Scope, selector, selectorWithDot))
                 {
                     index++;
                     if (index == len)
@@ -86,7 +85,7 @@ namespace TextMateSharp.Internal.Grammars
                     selector = parentScopes[index];
                     selectorWithDot = selector + '.';
                 }
-                target = target.parent;
+                target = target.Parent;
             }
 
             return false;
@@ -103,10 +102,10 @@ namespace TextMateSharp.Internal.Grammars
             int foreground = 0;
             int background = 0;
 
-            if (source.themeData != null)
+            if (source.ThemeData != null)
             {
                 // Find the first themeData that matches
-                foreach (ThemeTrieElementRule themeData in source.themeData)
+                foreach (ThemeTrieElementRule themeData in source.ThemeData)
                 {
                     if (Matches(scopesList, themeData.parentScopes))
                     {
@@ -118,7 +117,7 @@ namespace TextMateSharp.Internal.Grammars
                 }
             }
 
-            return StackElementMetadata.Set(metadata, source.languageId, source.tokenType, fontStyle, foreground,
+            return StackElementMetadata.Set(metadata, source.LanguageId, source.TokenType, fontStyle, foreground,
                     background);
         }
 
@@ -127,7 +126,7 @@ namespace TextMateSharp.Internal.Grammars
             foreach (string scope in scopes)
             {
                 ScopeMetadata rawMetadata = grammar.GetMetadataForScope(scope);
-                int metadata = ScopeListElement.mergeMetadata(target.metadata, target, rawMetadata);
+                int metadata = ScopeListElement.mergeMetadata(target.Metadata, target, rawMetadata);
                 target = new ScopeListElement(target, scope, metadata);
             }
             return target;
@@ -153,8 +152,8 @@ namespace TextMateSharp.Internal.Grammars
             List<string> result = new List<string>();
             while (scopesList != null)
             {
-                result.Add(scopesList.scope);
-                scopesList = scopesList.parent;
+                result.Add(scopesList.Scope);
+                scopesList = scopesList.Parent;
             }
             result.Reverse();
             return result;

--- a/src/TextMateSharp/Internal/Grammars/ScopeMetadata.cs
+++ b/src/TextMateSharp/Internal/Grammars/ScopeMetadata.cs
@@ -7,17 +7,17 @@ namespace TextMateSharp.Internal.Grammars
     public class ScopeMetadata
     {
 
-        public string scopeName;
-        public int languageId;
-        public int tokenType;
-        public List<ThemeTrieElementRule> themeData;
+        public string ScopeName { get; private set; }
+        public int LanguageId { get; private set; }
+        public int TokenType { get; private set; }
+        public List<ThemeTrieElementRule> ThemeData { get; private set; }
 
         public ScopeMetadata(string scopeName, int languageId, int tokenType, List<ThemeTrieElementRule> themeData)
         {
-            this.scopeName = scopeName;
-            this.languageId = languageId;
-            this.tokenType = tokenType;
-            this.themeData = themeData;
+            ScopeName = scopeName;
+            LanguageId = languageId;
+            TokenType = tokenType;
+            ThemeData = themeData;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Grammars/ScopeMetadataProvider.cs
+++ b/src/TextMateSharp/Internal/Grammars/ScopeMetadataProvider.cs
@@ -15,29 +15,29 @@ namespace TextMateSharp.Internal.Grammars
         private const string STRING_TOKEN_TYPE = "string";
         private const string REGEX_TOKEN_TYPE = "regex";
 
-        private int initialLanguage;
-        private IThemeProvider themeProvider;
-        private Dictionary<string, ScopeMetadata> cache;
-        private ScopeMetadata defaultMetaData;
-        private Dictionary<string, int> embeddedLanguages;
-        private Regex embeddedLanguagesRegex;
+        private int _initialLanguage;
+        private IThemeProvider _themeProvider;
+        private Dictionary<string, ScopeMetadata> _cache;
+        private ScopeMetadata _defaultMetaData;
+        private Dictionary<string, int> _embeddedLanguages;
+        private Regex _embeddedLanguagesRegex;
 
         public ScopeMetadataProvider(int initialLanguage, IThemeProvider themeProvider,
             Dictionary<string, int> embeddedLanguages)
         {
-            this.initialLanguage = initialLanguage;
-            this.themeProvider = themeProvider;
-            this.cache = new Dictionary<string, ScopeMetadata>();
+            this._initialLanguage = initialLanguage;
+            this._themeProvider = themeProvider;
+            this._cache = new Dictionary<string, ScopeMetadata>();
             this.OnDidChangeTheme();
 
             // embeddedLanguages handling
-            this.embeddedLanguages = new Dictionary<string, int>();
+            this._embeddedLanguages = new Dictionary<string, int>();
             if (embeddedLanguages != null)
             {
                 foreach (string scope in embeddedLanguages.Keys)
                 {
                     int languageId = embeddedLanguages[scope];
-                    this.embeddedLanguages[scope] = languageId;
+                    this._embeddedLanguages[scope] = languageId;
                 }
             }
 
@@ -48,7 +48,7 @@ namespace TextMateSharp.Internal.Grammars
 
             //if (escapedScopes.isEmpty()) {
                 // no scopes registered
-            this.embeddedLanguagesRegex = null;
+            this._embeddedLanguagesRegex = null;
             //} else {
                 // TODO!!!
                 //this.embeddedLanguagesRegex = null;
@@ -61,17 +61,17 @@ namespace TextMateSharp.Internal.Grammars
 
         public void OnDidChangeTheme()
         {
-            this.cache.Clear();
-            this.defaultMetaData = new ScopeMetadata(
+            this._cache.Clear();
+            this._defaultMetaData = new ScopeMetadata(
                 "",
-                this.initialLanguage,
+                this._initialLanguage,
                 StandardTokenType.Other,
-                new List<ThemeTrieElementRule>() { this.themeProvider.GetDefaults() });
+                new List<ThemeTrieElementRule>() { this._themeProvider.GetDefaults() });
         }
 
         public ScopeMetadata GetDefaultMetadata()
         {
-            return this.defaultMetaData;
+            return this._defaultMetaData;
         }
 
         private static string EscapeRegExpCharacters(string value)
@@ -87,13 +87,13 @@ namespace TextMateSharp.Internal.Grammars
                 return ScopeMetadataProvider._NULL_SCOPE_METADATA;
             }
             ScopeMetadata value;
-            this.cache.TryGetValue(scopeName, out value);
+            this._cache.TryGetValue(scopeName, out value);
             if (value != null)
             {
                 return value;
             }
             value = this.DoGetMetadataForScope(scopeName);
-            this.cache[scopeName] = value;
+            this._cache[scopeName] = value;
             return value;
         }
 
@@ -101,7 +101,7 @@ namespace TextMateSharp.Internal.Grammars
         {
             int languageId = this.ScopeToLanguage(scopeName);
             int standardTokenType = ScopeMetadataProvider.ToStandardTokenType(scopeName);
-            List<ThemeTrieElementRule> themeData = this.themeProvider.ThemeMatch(new string[] { scopeName });
+            List<ThemeTrieElementRule> themeData = this._themeProvider.ThemeMatch(new string[] { scopeName });
 
             return new ScopeMetadata(scopeName, languageId, standardTokenType, themeData);
         }
@@ -112,7 +112,7 @@ namespace TextMateSharp.Internal.Grammars
             {
                 return 0;
             }
-            if (this.embeddedLanguagesRegex == null)
+            if (this._embeddedLanguagesRegex == null)
             {
                 // no scopes registered
                 return 0;

--- a/src/TextMateSharp/Internal/Grammars/StackElementMetadata.cs
+++ b/src/TextMateSharp/Internal/Grammars/StackElementMetadata.cs
@@ -4,7 +4,6 @@ namespace TextMateSharp.Internal.Grammars
 {
     public static class StackElementMetadata
     {
-
         public static string ToBinaryStr(int metadata)
         {
             /*

--- a/src/TextMateSharp/Internal/Grammars/SyncRegistry.cs
+++ b/src/TextMateSharp/Internal/Grammars/SyncRegistry.cs
@@ -11,47 +11,47 @@ namespace TextMateSharp.Internal.Grammars
 {
     public class SyncRegistry : IGrammarRepository, IThemeProvider
     {
-        private Dictionary<string, IGrammar> grammars;
-        private Dictionary<string, IRawGrammar> rawGrammars;
-        private Dictionary<string, ICollection<string>> injectionGrammars;
-        private Theme theme;
+        private Dictionary<string, IGrammar> _grammars;
+        private Dictionary<string, IRawGrammar> _rawGrammars;
+        private Dictionary<string, ICollection<string>> _injectionGrammars;
+        private Theme _theme;
 
         public SyncRegistry(Theme theme)
         {
-            this.theme = theme;
-            this.grammars = new Dictionary<string, IGrammar>();
-            this.rawGrammars = new Dictionary<string, IRawGrammar>();
-            this.injectionGrammars = new Dictionary<string, ICollection<string>>();
+            _theme = theme;
+            _grammars = new Dictionary<string, IGrammar>();
+            _rawGrammars = new Dictionary<string, IRawGrammar>();
+            _injectionGrammars = new Dictionary<string, ICollection<string>>();
         }
 
         public Theme GetTheme()
         {
-            return theme;
+            return _theme;
         }
 
         public void SetTheme(Theme theme)
         {
-            this.theme = theme;
+            this._theme = theme;
 
-            foreach (IGrammar grammar in grammars.Values)
+            foreach (IGrammar grammar in _grammars.Values)
                 ((Grammar)grammar).OnDidChangeTheme();
 
         }
 
         public ICollection<string> GetColorMap()
         {
-            return this.theme.GetColorMap();
+            return this._theme.GetColorMap();
         }
 
         public ICollection<string> AddGrammar(IRawGrammar grammar, ICollection<string> injectionScopeNames)
         {
-            this.rawGrammars.Add(grammar.GetScopeName(), grammar);
+            this._rawGrammars.Add(grammar.GetScopeName(), grammar);
             ICollection<string> includedScopes = new List<string>();
             CollectIncludedScopes(includedScopes, grammar);
 
             if (injectionScopeNames != null)
             {
-                this.injectionGrammars.Add(grammar.GetScopeName(), injectionScopeNames);
+                this._injectionGrammars.Add(grammar.GetScopeName(), injectionScopeNames);
                 foreach (string scopeName in injectionScopeNames)
                 {
                     AddIncludedScope(scopeName, includedScopes);
@@ -63,41 +63,41 @@ namespace TextMateSharp.Internal.Grammars
         public IRawGrammar Lookup(string scopeName)
         {
             IRawGrammar result;
-            this.rawGrammars.TryGetValue(scopeName, out result);
+            this._rawGrammars.TryGetValue(scopeName, out result);
             return result;
         }
 
         public ICollection<string> Injections(string targetScope)
         {
             ICollection<string> result;
-            this.injectionGrammars.TryGetValue(targetScope, out result);
+            this._injectionGrammars.TryGetValue(targetScope, out result);
             return result;
         }
 
         public ThemeTrieElementRule GetDefaults()
         {
-            return this.theme.GetDefaults();
+            return this._theme.GetDefaults();
         }
 
         public List<ThemeTrieElementRule> ThemeMatch(IList<string> scopeNames)
         {
-            return this.theme.Match(scopeNames);
+            return this._theme.Match(scopeNames);
         }
 
         public IGrammar GrammarForScopeName(string scopeName, int initialLanguage,
                 Dictionary<string, int> embeddedLanguages)
         {
-            if (!this.grammars.ContainsKey(scopeName))
+            if (!this._grammars.ContainsKey(scopeName))
             {
                 IRawGrammar rawGrammar = Lookup(scopeName);
                 if (rawGrammar == null)
                 {
                     return null;
                 }
-                this.grammars.Add(scopeName,
+                this._grammars.Add(scopeName,
                         GrammarHelper.CreateGrammar(rawGrammar, initialLanguage, embeddedLanguages, this, this));
             }
-            return this.grammars[scopeName];
+            return this._grammars[scopeName];
         }
 
         private static void CollectIncludedScopes(ICollection<string> result, IRawGrammar grammar)

--- a/src/TextMateSharp/Internal/Grammars/Token.cs
+++ b/src/TextMateSharp/Internal/Grammars/Token.cs
@@ -17,9 +17,9 @@ namespace TextMateSharp.Internal.Grammars
 
         public Token(int startIndex, int endIndex, List<string> scopes)
         {
-            this.StartIndex = startIndex;
-            this.EndIndex = endIndex;
-            this.Scopes = scopes;
+            StartIndex = startIndex;
+            EndIndex = endIndex;
+            Scopes = scopes;
         }
 
         public override string ToString()

--- a/src/TextMateSharp/Internal/Grammars/TokenizeLineResult.cs
+++ b/src/TextMateSharp/Internal/Grammars/TokenizeLineResult.cs
@@ -9,8 +9,8 @@ namespace TextMateSharp.Internal.Grammars
 
         public TokenizeLineResult(IToken[] tokens, StackElement ruleStack)
         {
-            this.Tokens = tokens;
-            this.RuleStack = ruleStack;
+            Tokens = tokens;
+            RuleStack = ruleStack;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Grammars/TokenizeLineResult2.cs
+++ b/src/TextMateSharp/Internal/Grammars/TokenizeLineResult2.cs
@@ -4,24 +4,13 @@ namespace TextMateSharp.Internal.Grammars
 {
     public class TokenizeLineResult2 : ITokenizeLineResult2
     {
-
-        private int[] tokens;
-        private StackElement ruleStack;
+        public int[] Tokens { get; private set; }
+        public StackElement RuleStack { get; private set; }
 
         public TokenizeLineResult2(int[] tokens, StackElement ruleStack)
         {
-            this.tokens = tokens;
-            this.ruleStack = ruleStack;
-        }
-
-        public int[] GetTokens()
-        {
-            return tokens;
-        }
-
-        public StackElement GetRuleStack()
-        {
-            return ruleStack;
+            Tokens = tokens;
+            RuleStack = ruleStack;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Matcher/IMatchInjectionsResult.cs
+++ b/src/TextMateSharp/Internal/Matcher/IMatchInjectionsResult.cs
@@ -2,6 +2,6 @@ namespace TextMateSharp.Internal.Matcher
 {
     public interface IMatchInjectionsResult : IMatchResult
     {
-        bool IsPriorityMatch();
+        bool IsPriorityMatch { get; }
     }
 }

--- a/src/TextMateSharp/Internal/Matcher/IMatchResult.cs
+++ b/src/TextMateSharp/Internal/Matcher/IMatchResult.cs
@@ -4,8 +4,8 @@ namespace TextMateSharp.Internal.Matcher
 {
     public interface IMatchResult
     {
-        IOnigCaptureIndex[] GetCaptureIndices();
+        IOnigCaptureIndex[] CaptureIndexes { get; }
 
-        int? GetMatchedRuleId();
+        int? MatchedRuleId { get; }
     }
 }

--- a/src/TextMateSharp/Internal/Matcher/MatchInjectionResult.cs
+++ b/src/TextMateSharp/Internal/Matcher/MatchInjectionResult.cs
@@ -4,33 +4,18 @@ namespace TextMateSharp.Internal.Matcher
 {
     internal class MatchInjectionsResult : IMatchInjectionsResult
     {
-        private IOnigCaptureIndex[] captureIndexes;
-        private int? matchedRuleId;
-        private bool isPriorityMatch;
+        public IOnigCaptureIndex[] CaptureIndexes { get; private set; }
+        public int? MatchedRuleId { get; private set; }
+        public bool IsPriorityMatch { get; private set; }
 
         internal MatchInjectionsResult(
             IOnigCaptureIndex[] captureIndexes,
             int? matchedRuleId,
             bool isPriorityMatch)
         {
-            this.captureIndexes = captureIndexes;
-            this.matchedRuleId = matchedRuleId;
-            this.isPriorityMatch = isPriorityMatch;
-        }
-
-        public IOnigCaptureIndex[] GetCaptureIndices()
-        {
-            return captureIndexes;
-        }
-
-        public int? GetMatchedRuleId()
-        {
-            return matchedRuleId;
-        }
-
-        public bool IsPriorityMatch()
-        {
-            return isPriorityMatch;
+            CaptureIndexes = captureIndexes;
+            MatchedRuleId = matchedRuleId;
+            IsPriorityMatch = isPriorityMatch;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Matcher/MatchResult.cs
+++ b/src/TextMateSharp/Internal/Matcher/MatchResult.cs
@@ -4,23 +4,13 @@ namespace TextMateSharp.Internal.Matcher
 {
     class MatchResult : IMatchResult
     {
-        private IOnigCaptureIndex[] captureIndexes;
-        private int? matchedRuleId;
+        public IOnigCaptureIndex[] CaptureIndexes { get; private set; }
+        public int? MatchedRuleId { get; private set; }
 
         internal MatchResult(IOnigCaptureIndex[] captureIndexes, int? matchedRuleId)
         {
-            this.captureIndexes = captureIndexes;
-            this.matchedRuleId = matchedRuleId;
-        }
-
-        public IOnigCaptureIndex[] GetCaptureIndices()
-        {
-            return captureIndexes;
-        }
-
-        public int? GetMatchedRuleId()
-        {
-            return matchedRuleId;
+            CaptureIndexes = captureIndexes;
+            MatchedRuleId = matchedRuleId;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Matcher/MatcherWithPriority.cs
+++ b/src/TextMateSharp/Internal/Matcher/MatcherWithPriority.cs
@@ -4,13 +4,13 @@ namespace TextMateSharp.Internal.Matcher
 {
     public class MatcherWithPriority<T>
     {
-        public Predicate<T> matcher;
-        public int priority;
+        public Predicate<T> Matcher { get; private set; }
+        public int Priority { get; private set; }
 
         public MatcherWithPriority(Predicate<T> matcher, int priority)
         {
-            this.matcher = matcher;
-            this.priority = priority;
+            Matcher = matcher;
+            Priority = priority;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Oniguruma/IOnigCaptureIndex.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/IOnigCaptureIndex.cs
@@ -2,12 +2,12 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public interface IOnigCaptureIndex
     {
-        int GetIndex();
+        int Index { get; }
 
-        int GetStart();
+        int Start { get; }
 
-        int GetEnd();
+        int End { get; }
 
-        int GetLength();
+        int Length { get; }
     }
 }

--- a/src/TextMateSharp/Internal/Oniguruma/OnigNextMatchResult.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/OnigNextMatchResult.cs
@@ -4,24 +4,24 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     class OnigNextMatchResult : IOnigNextMatchResult
     {
-        private int index;
+        private int _index;
 
-        private IOnigCaptureIndex[] captureIndices;
+        private IOnigCaptureIndex[] _captureIndices;
 
         public OnigNextMatchResult(OnigResult result)
         {
-            this.index = result.GetIndex();
-            this.captureIndices = CaptureIndicesForMatch(result);
+            this._index = result.GetIndex();
+            this._captureIndices = CaptureIndicesForMatch(result);
         }
 
         public int GetIndex()
         {
-            return index;
+            return _index;
         }
 
         public IOnigCaptureIndex[] GetCaptureIndices()
         {
-            return captureIndices;
+            return _captureIndices;
         }
 
         public override string ToString()
@@ -66,49 +66,29 @@ namespace TextMateSharp.Internal.Oniguruma
 
         class OnigCaptureIndex : IOnigCaptureIndex
         {
-
-            private int index;
-            private int start;
-            private int end;
+            public int Index { get; private set; }
+            public int Start { get; private set; }
+            public int End { get; private set; }
+            public int Length { get { return End - Start; } }
 
             public OnigCaptureIndex(int index, int start, int end)
             {
-                this.index = index;
-                this.start = start >= 0 ? start : 0;
-                this.end = end >= 0 ? end : 0;
+                Index = index;
+                Start = start >= 0 ? start : 0;
+                End = end >= 0 ? end : 0;
             }
 
-            public int GetIndex()
-            {
-                return index;
-            }
-
-            public int GetStart()
-            {
-                return start;
-            }
-
-            public int GetEnd()
-            {
-                return end;
-            }
-
-            public int GetLength()
-            {
-                return end - start;
-            }
-
-            public string toString()
+            public override string ToString()
             {
                 StringBuilder result = new StringBuilder();
                 result.Append("{\"index\": ");
-                result.Append(GetIndex());
+                result.Append(Index);
                 result.Append(", \"start\": ");
-                result.Append(GetStart());
+                result.Append(Start);
                 result.Append(", \"end\": ");
-                result.Append(GetEnd());
+                result.Append(End);
                 result.Append(", \"length\": ");
-                result.Append(GetLength());
+                result.Append(Length);
                 result.Append("}");
                 return result.ToString();
             }

--- a/src/TextMateSharp/Internal/Oniguruma/OnigRegExp.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/OnigRegExp.cs
@@ -5,18 +5,19 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public class OnigRegExp : IDisposable
     {
-        private string lastSearchString;
-        private int lastSearchPosition;
-        private OnigResult lastSearchResult;
-        private ORegex regex;
+        private string _lastSearchString;
+        private int _lastSearchPosition;
+        private OnigResult _lastSearchResult;
+        private ORegex _regex;
         private bool _disposed;
+
         public OnigRegExp(string source)
         {
-            lastSearchString = null;
-            lastSearchPosition = -1;
-            lastSearchResult = null;
+            _lastSearchString = null;
+            _lastSearchPosition = -1;
+            _lastSearchResult = null;
 
-            regex = new ORegex(source, false, false);
+            _regex = new ORegex(source, false, false);
         }
 
         ~OnigRegExp() => Dispose(false);
@@ -34,29 +35,29 @@ namespace TextMateSharp.Internal.Oniguruma
                 return;
             }
 
-            if (regex != null)
-                regex.Dispose();
+            if (_regex != null)
+                _regex.Dispose();
             
             _disposed = true;
-        }        
+        }
         
         public OnigResult Search(string str, in int position)
         {
-            if (lastSearchString == str && lastSearchPosition <= position &&
-                (lastSearchResult == null || lastSearchResult.LocationAt(0) >= position))
+            if (_lastSearchString == str && _lastSearchPosition <= position &&
+                (_lastSearchResult == null || _lastSearchResult.LocationAt(0) >= position))
             {
-                return lastSearchResult;
+                return _lastSearchResult;
             }
 
-            lastSearchString = str;
-            lastSearchPosition = position;
-            lastSearchResult = GetOnigResult(str, position);
-            return lastSearchResult;
+            _lastSearchString = str;
+            _lastSearchPosition = position;
+            _lastSearchResult = GetOnigResult(str, position);
+            return _lastSearchResult;
         }
 
         private OnigResult GetOnigResult(string data, in int position)
         {
-            List<ORegexResult> results = regex.SafeSearch(data, position);
+            List<ORegexResult> results = _regex.SafeSearch(data, position);
 
             if (results == null || results.Count == 0)
                 return null;
@@ -65,8 +66,8 @@ namespace TextMateSharp.Internal.Oniguruma
 
             for (int i = 0; i < results.Count; i++)
             {
-                region.beg[i] = results[i].Position;
-                region.end[i] = results[i].Position + results[i].Length;
+                region.Start[i] = results[i].Position;
+                region.End[i] = results[i].Position + results[i].Length;
             }
 
             return new OnigResult(region, -1);

--- a/src/TextMateSharp/Internal/Oniguruma/OnigResult.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/OnigResult.cs
@@ -2,28 +2,28 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public class OnigResult
     {
-        private int indexInScanner;
-        private Region region;
+        private int _indexInScanner;
+        private Region _region;
 
         public OnigResult(Region region, int indexInScanner)
         {
-            this.region = region;
-            this.indexInScanner = indexInScanner;
+            this._region = region;
+            this._indexInScanner = indexInScanner;
         }
 
         public int GetIndex()
         {
-            return indexInScanner;
+            return _indexInScanner;
         }
 
         public void SetIndex(int index)
         {
-            this.indexInScanner = index;
+            this._indexInScanner = index;
         }
 
         public int LocationAt(int index)
         {
-            int bytes = region.beg[index];
+            int bytes = _region.Start[index];
             if (bytes > 0)
             {
                 return bytes;
@@ -36,12 +36,12 @@ namespace TextMateSharp.Internal.Oniguruma
 
         public int Count()
         {
-            return region.numRegs;
+            return _region.NumRegs;
         }
 
         public int LengthAt(int index)
         {
-            int bytes = region.end[index] - region.beg[index];
+            int bytes = _region.End[index] - _region.Start[index];
             if (bytes > 0)
             {
                 return bytes;

--- a/src/TextMateSharp/Internal/Oniguruma/OnigScanner.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/OnigScanner.cs
@@ -2,16 +2,16 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public class OnigScanner
     {
-        private OnigSearcher searcher;
+        private OnigSearcher _searcher;
 
         public OnigScanner(string[] regexps)
         {
-            this.searcher = new OnigSearcher(regexps);
+            this._searcher = new OnigSearcher(regexps);
         }
 
         public IOnigNextMatchResult FindNextMatchSync(string source, in int charOffset)
         {
-            OnigResult bestResult = searcher.Search(source, charOffset);
+            OnigResult bestResult = _searcher.Search(source, charOffset);
             if (bestResult != null)
             {
                 return new OnigNextMatchResult(bestResult);

--- a/src/TextMateSharp/Internal/Oniguruma/OnigSearcher.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/OnigSearcher.cs
@@ -2,18 +2,16 @@ using System.Collections.Generic;
 
 namespace TextMateSharp.Internal.Oniguruma
 {
-
     public class OnigSearcher
     {
-
-        private List<OnigRegExp> regExps;
+        private List<OnigRegExp> _regExps;
 
         public OnigSearcher(string[] regexps)
         {
-            regExps = new List<OnigRegExp>(regexps.Length);
+            _regExps = new List<OnigRegExp>(regexps.Length);
             foreach (string regexp in regexps)
             {
-                regExps.Add(new OnigRegExp(regexp));
+                _regExps.Add(new OnigRegExp(regexp));
             }
         }
 
@@ -25,7 +23,7 @@ namespace TextMateSharp.Internal.Oniguruma
             OnigResult bestResult = null;
             int index = 0;
 
-            foreach (OnigRegExp regExp in regExps)
+            foreach (OnigRegExp regExp in _regExps)
             {
                 OnigResult result = regExp.Search(source, byteOffset);
                 if (result != null && result.Count() > 0)

--- a/src/TextMateSharp/Internal/Oniguruma/Region.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/Region.cs
@@ -4,22 +4,22 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public class Region
     {
-        public readonly int numRegs;
-        public int[] beg;
-        public int[] end;
+        public int NumRegs { get; private set; }
+        public int[] Start { get; private set; }
+        public int[] End { get; private set; }
 
         public Region(in int num)
         {
-            this.numRegs = num;
-            this.beg = new int[num];
-            this.end = new int[num];
+            NumRegs = num;
+            Start = new int[num];
+            End = new int[num];
         }
 
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("Region: \n");
-            for (int i = 0; i < beg.Length; i++) sb.Append(" " + i + ": (" + beg[i] + "-" + end[i] + ")");
+            for (int i = 0; i < Start.Length; i++) sb.Append(" " + i + ": (" + Start[i] + "-" + End[i] + ")");
             return sb.ToString();
         }
     }

--- a/src/TextMateSharp/Internal/Oniguruma/UnicodeCharEscape.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/UnicodeCharEscape.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace TextMateSharp.Internal.Oniguruma
 {

--- a/src/TextMateSharp/Internal/Rules/CaptureRule.cs
+++ b/src/TextMateSharp/Internal/Rules/CaptureRule.cs
@@ -4,11 +4,11 @@ namespace TextMateSharp.Internal.Rules
 {
     public class CaptureRule : Rule
     {
-        public int? retokenizeCapturedWithRuleId;
+        public int? RetokenizeCapturedWithRuleId { get; private set; }
 
         public CaptureRule(int? id, string name, string contentName, int? retokenizeCapturedWithRuleId) : base(id, name, contentName)
         {
-            this.retokenizeCapturedWithRuleId = retokenizeCapturedWithRuleId;
+            RetokenizeCapturedWithRuleId = retokenizeCapturedWithRuleId;
         }
 
         public override void CollectPatternsRecursive(IRuleRegistry grammar, RegExpSourceList sourceList, bool isFirst)

--- a/src/TextMateSharp/Internal/Rules/ICompilePatternsResult.cs
+++ b/src/TextMateSharp/Internal/Rules/ICompilePatternsResult.cs
@@ -4,13 +4,13 @@ namespace TextMateSharp.Internal.Rules
 {
     public class ICompilePatternsResult
     {
-        public int?[] patterns;
-        public bool hasMissingPatterns;
+        public int?[] Patterns { get; private set; }
+        public bool HasMissingPatterns { get; private set; }
 
         public ICompilePatternsResult(IEnumerable<int?> patterns, bool hasMissingPatterns)
         {
-            this.hasMissingPatterns = hasMissingPatterns;
-            this.patterns = new List<int?>(patterns).ToArray();
+            HasMissingPatterns = hasMissingPatterns;
+            Patterns = new List<int?>(patterns).ToArray();
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/ICompiledRule.cs
+++ b/src/TextMateSharp/Internal/Rules/ICompiledRule.cs
@@ -4,13 +4,13 @@ namespace TextMateSharp.Internal.Rules
 {
     public class ICompiledRule
     {
-        public OnigScanner scanner;
-        public int?[] rules;
+        public OnigScanner Scanner { get; private set; }
+        public int?[] Rules { get; private set; }
 
         public ICompiledRule(OnigScanner scanner, int?[] rules)
         {
-            this.scanner = scanner;
-            this.rules = rules;
+            Scanner = scanner;
+            Rules = rules;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/IRegExpSourceAnchorCache.cs
+++ b/src/TextMateSharp/Internal/Rules/IRegExpSourceAnchorCache.cs
@@ -2,18 +2,17 @@ namespace TextMateSharp.Internal.Rules
 {
     public class IRegExpSourceAnchorCache
     {
+        public string A0_G0 { get; private set; }
+        public string A0_G1 { get; private set; }
+        public string A1_G0 { get; private set; }
+        public string A1_G1 { get; private set; }
 
-        public string A0_G0;
-        public string A0_G1;
-        public string A1_G0;
-        public string A1_G1;
-
-        public IRegExpSourceAnchorCache(string A0_G0, string A0_G1, string A1_G0, string A1_G1)
+        public IRegExpSourceAnchorCache(string a0_G0, string a0_G1, string a1_G0, string a1_G1)
         {
-            this.A0_G0 = A0_G0;
-            this.A0_G1 = A0_G1;
-            this.A1_G0 = A1_G0;
-            this.A1_G1 = A1_G1;
+            A0_G0 = A0_G0;
+            A0_G1 = A0_G1;
+            A1_G0 = A1_G0;
+            A1_G1 = A1_G1;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/IRegExpSourceAnchorCache.cs
+++ b/src/TextMateSharp/Internal/Rules/IRegExpSourceAnchorCache.cs
@@ -9,10 +9,10 @@ namespace TextMateSharp.Internal.Rules
 
         public IRegExpSourceAnchorCache(string a0_G0, string a0_G1, string a1_G0, string a1_G1)
         {
-            A0_G0 = A0_G0;
-            A0_G1 = A0_G1;
-            A1_G0 = A1_G0;
-            A1_G1 = A1_G1;
+            A0_G0 = a0_G0;
+            A0_G1 = a0_G1;
+            A1_G0 = a1_G0;
+            A1_G1 = a1_G1;
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/IncludeOnlyRule.cs
+++ b/src/TextMateSharp/Internal/Rules/IncludeOnlyRule.cs
@@ -2,20 +2,22 @@ namespace TextMateSharp.Internal.Rules
 {
     public class IncludeOnlyRule : Rule
     {
-        public bool hasMissingPatterns;
-        public int?[] patterns;
-        private RegExpSourceList cachedCompiledPatterns;
+        public bool HasMissingPatterns { get; private set; }
+        public int?[] Patterns { get; private set; }
+
+        private RegExpSourceList _cachedCompiledPatterns;
 
         public IncludeOnlyRule(int? id, string name, string contentName, ICompilePatternsResult patterns) : base(id, name, contentName)
         {
-            this.patterns = patterns.patterns;
-            this.hasMissingPatterns = patterns.hasMissingPatterns;
-            this.cachedCompiledPatterns = null;
+            Patterns = patterns.Patterns;
+            HasMissingPatterns = patterns.HasMissingPatterns;
+
+            _cachedCompiledPatterns = null;
         }
 
         public override void CollectPatternsRecursive(IRuleRegistry grammar, RegExpSourceList sourceList, bool isFirst)
         {
-            foreach (int pattern in this.patterns)
+            foreach (int pattern in this.Patterns)
             {
                 Rule rule = grammar.GetRule(pattern);
                 rule.CollectPatternsRecursive(grammar, sourceList, false);
@@ -24,12 +26,12 @@ namespace TextMateSharp.Internal.Rules
 
         public override ICompiledRule Compile(IRuleRegistry grammar, string endRegexSource, bool allowA, bool allowG)
         {
-            if (this.cachedCompiledPatterns == null)
+            if (this._cachedCompiledPatterns == null)
             {
-                this.cachedCompiledPatterns = new RegExpSourceList();
-                this.CollectPatternsRecursive(grammar, this.cachedCompiledPatterns, true);
+                this._cachedCompiledPatterns = new RegExpSourceList();
+                this.CollectPatternsRecursive(grammar, this._cachedCompiledPatterns, true);
             }
-            return this.cachedCompiledPatterns.Compile(grammar, allowA, allowG);
+            return this._cachedCompiledPatterns.Compile(grammar, allowA, allowG);
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/MatchRule.cs
+++ b/src/TextMateSharp/Internal/Rules/MatchRule.cs
@@ -4,31 +4,31 @@ namespace TextMateSharp.Internal.Rules
 {
     public class MatchRule : Rule
     {
+        public List<CaptureRule> Captures { get; private set; }
 
-        private RegExpSource match;
-        public List<CaptureRule> captures;
-        private RegExpSourceList cachedCompiledPatterns;
+        private RegExpSource _match;
+        private RegExpSourceList _cachedCompiledPatterns;
 
         public MatchRule(int? id, string name, string match, List<CaptureRule> captures) : base(id, name, null)
         {
-            this.match = new RegExpSource(match, this.id);
-            this.captures = captures;
-            this.cachedCompiledPatterns = null;
+            this._match = new RegExpSource(match, this.Id);
+            this.Captures = captures;
+            this._cachedCompiledPatterns = null;
         }
 
         public override void CollectPatternsRecursive(IRuleRegistry grammar, RegExpSourceList sourceList, bool isFirst)
         {
-            sourceList.Push(this.match);
+            sourceList.Push(this._match);
         }
 
         public override ICompiledRule Compile(IRuleRegistry grammar, string endRegexSource, bool allowA, bool allowG)
         {
-            if (this.cachedCompiledPatterns == null)
+            if (this._cachedCompiledPatterns == null)
             {
-                this.cachedCompiledPatterns = new RegExpSourceList();
-                this.CollectPatternsRecursive(grammar, this.cachedCompiledPatterns, true);
+                this._cachedCompiledPatterns = new RegExpSourceList();
+                this.CollectPatternsRecursive(grammar, this._cachedCompiledPatterns, true);
             }
-            return this.cachedCompiledPatterns.Compile(grammar, allowA, allowG);
+            return this._cachedCompiledPatterns.Compile(grammar, allowA, allowG);
         }
     }
 }

--- a/src/TextMateSharp/Internal/Rules/RegExpSource.cs
+++ b/src/TextMateSharp/Internal/Rules/RegExpSource.cs
@@ -15,11 +15,11 @@ namespace TextMateSharp.Internal.Rules
         private static Regex BACK_REFERENCING_END = new Regex("\\\\(\\d+)");
         private static Regex REGEXP_CHARACTERS = new Regex("[\\-\\\\\\{\\}\\*\\+\\?\\|\\^\\$\\.\\,\\[\\]\\(\\)\\#\\s]");
 
-        private int? ruleId;
+        private int? _ruleId;
         private bool _hasAnchor;
         private bool _hasBackReferences;
-        private IRegExpSourceAnchorCache anchorCache;
-        private string source;
+        private IRegExpSourceAnchorCache _anchorCache;
+        private string _source;
 
         public RegExpSource(string regExpSource, int? ruleId) :
             this(regExpSource, ruleId, true)
@@ -34,35 +34,35 @@ namespace TextMateSharp.Internal.Rules
             }
             else
             {
-                this.source = regExpSource;
+                this._source = regExpSource;
                 this._hasAnchor = false;
             }
 
             if (this._hasAnchor)
             {
-                this.anchorCache = this.BuildAnchorCache();
+                this._anchorCache = this.BuildAnchorCache();
             }
 
-            this.ruleId = ruleId;
-            this._hasBackReferences = HAS_BACK_REFERENCES.Match(this.source).Success;
+            this._ruleId = ruleId;
+            this._hasBackReferences = HAS_BACK_REFERENCES.Match(this._source).Success;
         }
 
         public RegExpSource Clone()
         {
-            return new RegExpSource(this.source, this.ruleId, true);
+            return new RegExpSource(this._source, this._ruleId, true);
         }
 
-        public void setSource(string newSource)
+        public void SetSource(string newSource)
         {
-            if (this.source.Equals(newSource))
+            if (this._source.Equals(newSource))
             {
                 return;
             }
-            this.source = newSource;
+            this._source = newSource;
 
             if (this._hasAnchor)
             {
-                this.anchorCache = this.BuildAnchorCache();
+                this._anchorCache = this.BuildAnchorCache();
             }
         }
 
@@ -105,18 +105,18 @@ namespace TextMateSharp.Internal.Rules
                 if (lastPushedPos == 0)
                 {
                     // No \z hit
-                    this.source = regExpSource;
+                    this._source = regExpSource;
                 }
                 else
                 {
                     output.Append(regExpSource.SubstringAtIndexes(lastPushedPos, len));
-                    this.source = output.ToString();
+                    this._source = output.ToString();
                 }
             }
             else
             {
                 this._hasAnchor = false;
-                this.source = regExpSource;
+                this._source = regExpSource;
             }
         }
 
@@ -129,11 +129,11 @@ namespace TextMateSharp.Internal.Rules
                 foreach (IOnigCaptureIndex captureIndex in captureIndices)
                 {
                     capturedValues.Add(lineText.SubstringAtIndexes(
-                        captureIndex.GetStart(),
-                        captureIndex.GetEnd()));
+                        captureIndex.Start,
+                        captureIndex.End));
                 }
 
-                return BACK_REFERENCING_END.Replace(this.source, m =>
+                return BACK_REFERENCING_END.Replace(this._source, m =>
                 {
                     string value = m.Value;
                     int index = int.Parse(m.Value.SubstringAtIndexes(1, value.Length));
@@ -167,9 +167,9 @@ namespace TextMateSharp.Internal.Rules
             char ch;
             char nextCh;
 
-            for (pos = 0, len = this.source.Length; pos < len; pos++)
+            for (pos = 0, len = this._source.Length; pos < len; pos++)
             {
-                ch = this.source[pos];
+                ch = this._source[pos];
                 A0_G0_result.Append(ch);
                 A0_G1_result.Append(ch);
                 A1_G0_result.Append(ch);
@@ -179,7 +179,7 @@ namespace TextMateSharp.Internal.Rules
                 {
                     if (pos + 1 < len)
                     {
-                        nextCh = this.source[pos + 1];
+                        nextCh = this._source[pos + 1];
                         if (nextCh == 'A')
                         {
                             A0_G0_result.Append('\uFFFF');
@@ -217,29 +217,29 @@ namespace TextMateSharp.Internal.Rules
         {
             if (!this._hasAnchor)
             {
-                return this.source;
+                return this._source;
             }
 
             if (allowA)
             {
                 if (allowG)
                 {
-                    return this.anchorCache.A1_G1;
+                    return this._anchorCache.A1_G1;
                 }
                 else
                 {
-                    return this.anchorCache.A1_G0;
+                    return this._anchorCache.A1_G0;
                 }
             }
             else
             {
                 if (allowG)
                 {
-                    return this.anchorCache.A0_G1;
+                    return this._anchorCache.A0_G1;
                 }
                 else
                 {
-                    return this.anchorCache.A0_G0;
+                    return this._anchorCache.A0_G0;
                 }
             }
         }
@@ -251,12 +251,12 @@ namespace TextMateSharp.Internal.Rules
 
         public string GetSource()
         {
-            return this.source;
+            return this._source;
         }
 
         public int? GetRuleId()
         {
-            return this.ruleId;
+            return this._ruleId;
         }
 
         public bool HasBackReferences()

--- a/src/TextMateSharp/Internal/Rules/RegExpSourceList.cs
+++ b/src/TextMateSharp/Internal/Rules/RegExpSourceList.cs
@@ -57,7 +57,8 @@ namespace TextMateSharp.Internal.Rules
                 this._anchorCache.A0_G1 = null;
                 this._anchorCache.A1_G0 = null;
                 this._anchorCache.A1_G1 = null;
-                r.setSource(newSource);
+
+                r.SetSource(newSource);
             }
         }
 
@@ -80,22 +81,22 @@ namespace TextMateSharp.Internal.Rules
             {
                 if (this._anchorCache.A0_G0 == null)
                 {
-                    this._anchorCache.A0_G0 = (allowA == false && allowG == false) ? this._resolveAnchors(allowA, allowG)
+                    this._anchorCache.A0_G0 = (allowA == false && allowG == false) ? this.ResolveAnchors(allowA, allowG)
                             : null;
                 }
                 if (this._anchorCache.A0_G1 == null)
                 {
-                    this._anchorCache.A0_G1 = (allowA == false && allowG == true) ? this._resolveAnchors(allowA, allowG)
+                    this._anchorCache.A0_G1 = (allowA == false && allowG == true) ? this.ResolveAnchors(allowA, allowG)
                             : null;
                 }
                 if (this._anchorCache.A1_G0 == null)
                 {
-                    this._anchorCache.A1_G0 = (allowA == true && allowG == false) ? this._resolveAnchors(allowA, allowG)
+                    this._anchorCache.A1_G0 = (allowA == true && allowG == false) ? this.ResolveAnchors(allowA, allowG)
                             : null;
                 }
                 if (this._anchorCache.A1_G1 == null)
                 {
-                    this._anchorCache.A1_G1 = (allowA == true && allowG == true) ? this._resolveAnchors(allowA, allowG)
+                    this._anchorCache.A1_G1 = (allowA == true && allowG == true) ? this.ResolveAnchors(allowA, allowG)
                             : null;
                 }
                 if (allowA)
@@ -124,7 +125,7 @@ namespace TextMateSharp.Internal.Rules
 
         }
 
-        private ICompiledRule _resolveAnchors(bool allowA, bool allowG)
+        private ICompiledRule ResolveAnchors(bool allowA, bool allowG)
         {
             List<string> regexps = new List<string>();
             foreach (RegExpSource regExpSource in _items)

--- a/src/TextMateSharp/Internal/Rules/Rule.cs
+++ b/src/TextMateSharp/Internal/Rules/Rule.cs
@@ -3,47 +3,47 @@ using TextMateSharp.Internal.Utils;
 
 namespace TextMateSharp.Internal.Rules
 {
-	public abstract class Rule
-	{
+    public abstract class Rule
+    {
+        public int? Id { get; private set; }
 
-		public int? id;
+        private bool _nameIsCapturing;
+        private string _name;
 
-		private bool nameIsCapturing;
-		private string name;
+        private bool _contentNameIsCapturing;
+        private string _contentName;
 
-		private bool contentNameIsCapturing;
-		private string contentName;
+        public Rule(int? id, string name, string contentName)
+        {
+            Id = id;
 
-		public Rule(int? id, string name, string contentName)
-		{
-			this.id = id;
-			this.name = name;
-			this.nameIsCapturing = RegexSource.HasCaptures(this.name);
-			this.contentName = contentName;
-			this.contentNameIsCapturing = RegexSource.HasCaptures(this.contentName);
-		}
+            _name = name;
+            _nameIsCapturing = RegexSource.HasCaptures(this._name);
+            _contentName = contentName;
+            _contentNameIsCapturing = RegexSource.HasCaptures(this._contentName);
+        }
 
-		public string GetName(string lineText, IOnigCaptureIndex[] captureIndices)
-		{
-			if (!this.nameIsCapturing)
-			{
-				return this.name;
-			}
+        public string GetName(string lineText, IOnigCaptureIndex[] captureIndices)
+        {
+            if (!this._nameIsCapturing)
+            {
+                return this._name;
+            }
 
-			return RegexSource.ReplaceCaptures(this.name, lineText, captureIndices);
-		}
+            return RegexSource.ReplaceCaptures(this._name, lineText, captureIndices);
+        }
 
-		public string GetContentName(string lineText, IOnigCaptureIndex[] captureIndices)
-		{
-			if (!this.contentNameIsCapturing)
-			{
-				return this.contentName;
-			}
-			return RegexSource.ReplaceCaptures(this.contentName, lineText, captureIndices);
-		}
+        public string GetContentName(string lineText, IOnigCaptureIndex[] captureIndices)
+        {
+            if (!this._contentNameIsCapturing)
+            {
+                return this._contentName;
+            }
+            return RegexSource.ReplaceCaptures(this._contentName, lineText, captureIndices);
+        }
 
-		public abstract void CollectPatternsRecursive(IRuleRegistry grammar, RegExpSourceList sourceList, bool isFirst);
+        public abstract void CollectPatternsRecursive(IRuleRegistry grammar, RegExpSourceList sourceList, bool isFirst);
 
-		public abstract ICompiledRule Compile(IRuleRegistry grammar, string endRegexSource, bool allowA, bool allowG);
-	}
+        public abstract ICompiledRule Compile(IRuleRegistry grammar, string endRegexSource, bool allowA, bool allowG);
+    }
 }

--- a/src/TextMateSharp/Internal/Rules/RuleFactory.cs
+++ b/src/TextMateSharp/Internal/Rules/RuleFactory.cs
@@ -8,7 +8,6 @@ namespace TextMateSharp.Internal.Rules
 {
     public class RuleFactory
     {
-
         public static CaptureRule CreateCaptureRule(IRuleFactoryHelper helper, string name, string contentName,
                 int? retokenizeCapturedWithRuleId)
         {
@@ -228,7 +227,7 @@ namespace TextMateSharp.Internal.Rules
                         if (rule is IncludeOnlyRule)
                         {
                             IncludeOnlyRule ior = (IncludeOnlyRule)rule;
-                            if (ior.hasMissingPatterns && ior.patterns.Length == 0)
+                            if (ior.HasMissingPatterns && ior.Patterns.Length == 0)
                             {
                                 skipRule = true;
                             }
@@ -236,7 +235,7 @@ namespace TextMateSharp.Internal.Rules
                         else if (rule is BeginEndRule)
                         {
                             BeginEndRule br = (BeginEndRule)rule;
-                            if (br.hasMissingPatterns && br.patterns.Length == 0)
+                            if (br.HasMissingPatterns && br.Patterns.Length == 0)
                             {
                                 skipRule = true;
                             }
@@ -244,7 +243,7 @@ namespace TextMateSharp.Internal.Rules
                         else if (rule is BeginWhileRule)
                         {
                             BeginWhileRule br = (BeginWhileRule)rule;
-                            if (br.hasMissingPatterns && br.patterns.Length == 0)
+                            if (br.HasMissingPatterns && br.Patterns.Length == 0)
                             {
                                 skipRule = true;
                             }

--- a/src/TextMateSharp/Internal/Utils/CompareUtils.cs
+++ b/src/TextMateSharp/Internal/Utils/CompareUtils.cs
@@ -4,7 +4,7 @@ namespace TextMateSharp.Internal.Utils
 {
     public class CompareUtils
     {
-        public static int Strcmp(string a, string b)
+        public static int StrCmp(string a, string b)
         {
             if (a == null && b == null)
             {
@@ -57,7 +57,7 @@ namespace TextMateSharp.Internal.Utils
             {
                 for (int i = 0; i < len1; i++)
                 {
-                    int res = Strcmp(a[i], b[i]);
+                    int res = StrCmp(a[i], b[i]);
                     if (res != 0)
                     {
                         return res;

--- a/src/TextMateSharp/Internal/Utils/RegexSource.cs
+++ b/src/TextMateSharp/Internal/Utils/RegexSource.cs
@@ -42,7 +42,7 @@ namespace TextMateSharp.Internal.Utils
             IOnigCaptureIndex capture = captureIndices.Length > index ? captureIndices[index] : null;
             if (capture != null)
             {
-                string result = captureSource.SubstringAtIndexes(capture.GetStart(), capture.GetEnd());
+                string result = captureSource.SubstringAtIndexes(capture.Start, capture.End);
                 // Remove leading dots that would make the selector invalid
                 while (result.Length > 0 && result[0] == '.')
                 {

--- a/src/TextMateSharp/Model/AbstractLineList.cs
+++ b/src/TextMateSharp/Model/AbstractLineList.cs
@@ -5,11 +5,9 @@ namespace TextMateSharp.Model
 {
     public abstract class AbstractLineList : IModelLines
     {
-        //private static final Logger LOGGER = Logger.getLogger(AbstractLineList.class.getName());
+        private IList<ModelLine> _list = new List<ModelLine>();
 
-        private IList<ModelLine> list = new List<ModelLine>();
-
-        private TMModel model;
+        private TMModel _model;
 
         public AbstractLineList()
         {
@@ -17,14 +15,14 @@ namespace TextMateSharp.Model
 
         public void SetModel(TMModel model)
         {
-            this.model = model;
+            this._model = model;
         }
 
         public void AddLine(int line)
         {
             lock (mLock)
             {
-                this.list.Insert(line, new ModelLine());
+                this._list.Insert(line, new ModelLine());
             }
         }
 
@@ -32,7 +30,7 @@ namespace TextMateSharp.Model
         {
             lock (mLock)
             {
-                this.list.RemoveAt(line);
+                this._list.RemoveAt(line);
             }
         }
 
@@ -40,10 +38,10 @@ namespace TextMateSharp.Model
         {
             lock (mLock)
             {
-                if (index < 0 || index >= this.list.Count)
+                if (index < 0 || index >= this._list.Count)
                     return null;
 
-                return this.list[index];
+                return this._list[index];
             }
         }
 
@@ -51,32 +49,32 @@ namespace TextMateSharp.Model
         {
             lock (mLock)
             {
-                foreach (ModelLine modelLine in list)
+                foreach (ModelLine modelLine in _list)
                     action(modelLine);
             }
         }
 
         protected void InvalidateLine(int lineIndex)
         {
-            if (model != null)
+            if (_model != null)
             {
-                model.InvalidateLine(lineIndex);
+                _model.InvalidateLine(lineIndex);
             }
         }
 
         protected void InvalidateLineRange(int iniLineIndex, int endLineIndex)
         {
-            if (model != null)
+            if (_model != null)
             {
-                model.InvalidateLineRange(iniLineIndex, endLineIndex);
+                _model.InvalidateLineRange(iniLineIndex, endLineIndex);
             }
         }
 
         protected void ForceTokenization(int startLineIndex, int endLineIndex)
         {
-            if (model != null)
+            if (_model != null)
             {
-                model.ForceTokenization(startLineIndex, endLineIndex);
+                _model.ForceTokenization(startLineIndex, endLineIndex);
             }
         }
 

--- a/src/TextMateSharp/Model/DecodeMap.cs
+++ b/src/TextMateSharp/Model/DecodeMap.cs
@@ -6,25 +6,27 @@ namespace TextMateSharp.Model
 {
     class DecodeMap
     {
-        int lastAssignedId;
-        Dictionary<string /* scope */, int[] /* ids */ > scopeToTokenIds;
-        Dictionary<string /* token */, int?/* id */ > tokenToTokenId;
-        Dictionary<int/* id */, string /* id */ > tokenIdToToken;
-        public TMTokenDecodeData prevToken;
+        public TMTokenDecodeData PrevToken { get; set; }
+
+        private int lastAssignedId;
+        private Dictionary<string /* scope */, int[] /* ids */ > _scopeToTokenIds;
+        private Dictionary<string /* token */, int?/* id */ > _tokenToTokenId;
+        private Dictionary<int/* id */, string /* id */ > _tokenIdToToken;
 
         public DecodeMap()
         {
+            this.PrevToken = new TMTokenDecodeData(new string[0], new Dictionary<int, Dictionary<int, bool>>());
+
             this.lastAssignedId = 0;
-            this.scopeToTokenIds = new Dictionary<string, int[]>();
-            this.tokenToTokenId = new Dictionary<string, int?>();
-            this.tokenIdToToken = new Dictionary<int, string>();
-            this.prevToken = new TMTokenDecodeData(new string[0], new Dictionary<int, Dictionary<int, bool>>());
+            this._scopeToTokenIds = new Dictionary<string, int[]>();
+            this._tokenToTokenId = new Dictionary<string, int?>();
+            this._tokenIdToToken = new Dictionary<int, string>();
         }
 
         public int[] getTokenIds(string scope)
         {
             int[] tokens;
-            this.scopeToTokenIds.TryGetValue(scope, out tokens);
+            this._scopeToTokenIds.TryGetValue(scope, out tokens);
             if (tokens != null)
             {
                 return tokens;
@@ -37,17 +39,17 @@ namespace TextMateSharp.Model
             {
                 string token = tmpTokens[i];
                 int? tokenId;
-                this.tokenToTokenId.TryGetValue(token, out tokenId);
+                this._tokenToTokenId.TryGetValue(token, out tokenId);
                 if (tokenId == null)
                 {
                     tokenId = (++this.lastAssignedId);
-                    this.tokenToTokenId[token] = tokenId.Value;
-                    this.tokenIdToToken[tokenId.Value] = token;
+                    this._tokenToTokenId[token] = tokenId.Value;
+                    this._tokenIdToToken[tokenId.Value] = token;
                 }
                 tokens[i] = tokenId.Value;
             }
 
-            this.scopeToTokenIds[scope] = tokens;
+            this._scopeToTokenIds[scope] = tokens;
             return tokens;
         }
 
@@ -62,12 +64,12 @@ namespace TextMateSharp.Model
                     if (isFirst)
                     {
                         isFirst = false;
-                        result.Append(this.tokenIdToToken[i]);
+                        result.Append(this._tokenIdToToken[i]);
                     }
                     else
                     {
                         result.Append(".");
-                        result.Append(this.tokenIdToToken[i]);
+                        result.Append(this._tokenIdToToken[i]);
                     }
                 }
             }

--- a/src/TextMateSharp/Model/ITokenizationSupport.cs
+++ b/src/TextMateSharp/Model/ITokenizationSupport.cs
@@ -2,7 +2,6 @@ namespace TextMateSharp.Model
 {
     public interface ITokenizationSupport
     {
-
         TMState GetInitialState();
 
         LineTokens Tokenize(string line, TMState state);

--- a/src/TextMateSharp/Model/LineTokens.cs
+++ b/src/TextMateSharp/Model/LineTokens.cs
@@ -4,30 +4,15 @@ namespace TextMateSharp.Model
 {
     public class LineTokens
     {
-        public List<TMToken> Tokens;
-        public int ActualStopOffset;
-        public TMState EndState;
+        public List<TMToken> Tokens { get; private set; }
+        public int ActualStopOffset { get; set; }
+        public TMState EndState { get; set; }
 
         public LineTokens(List<TMToken> tokens, int actualStopOffset, TMState endState)
         {
-            this.Tokens = tokens;
-            this.ActualStopOffset = actualStopOffset;
-            this.EndState = endState;
-        }
-
-        public TMState GetEndState()
-        {
-            return EndState;
-        }
-
-        public void SetEndState(TMState endState)
-        {
-            this.EndState = endState;
-        }
-
-        public List<TMToken> GetTokens()
-        {
-            return Tokens;
+            Tokens = tokens;
+            ActualStopOffset = actualStopOffset;
+            EndState = endState;
         }
     }
 }

--- a/src/TextMateSharp/Model/ModelLine.cs
+++ b/src/TextMateSharp/Model/ModelLine.cs
@@ -4,34 +4,19 @@ namespace TextMateSharp.Model
 {
     public class ModelLine
     {
-        public bool IsInvalid = true;
-        public TMState State;
-        public List<TMToken> Tokens;
+        public bool IsInvalid { get; set; }
+        public TMState State { get; set; }
+        public List<TMToken> Tokens { get; set; }
+
+        public ModelLine()
+        {
+            IsInvalid = true;
+        }
 
         public void ResetTokenizationState()
         {
-            this.State = null;
-            this.Tokens = null;
-        }
-
-        public TMState GetState()
-        {
-            return State;
-        }
-
-        public void SetState(TMState state)
-        {
-            this.State = state;
-        }
-
-        public void SetTokens(List<TMToken> tokens)
-        {
-            this.Tokens = tokens;
-        }
-
-        public List<TMToken> GetTokens()
-        {
-            return Tokens;
+            State = null;
+            Tokens = null;
         }
     }
 }

--- a/src/TextMateSharp/Model/ModelTokensChangedEvent.cs
+++ b/src/TextMateSharp/Model/ModelTokensChangedEvent.cs
@@ -4,8 +4,8 @@ namespace TextMateSharp.Model
 {
     public class ModelTokensChangedEvent
     {
-        public List<Range> ranges;
-        public ITMModel model;
+        public List<Range> Ranges { get; private set; }
+        public ITMModel Model { get; private set; }
 
         public ModelTokensChangedEvent(Range range, ITMModel model) :
             this(new List<Range>() { range }, model)
@@ -14,8 +14,8 @@ namespace TextMateSharp.Model
 
         public ModelTokensChangedEvent(List<Range> ranges, ITMModel model)
         {
-            this.ranges = ranges;
-            this.model = model;
+            Ranges = ranges;
+            Model = model;
         }
     }
 }

--- a/src/TextMateSharp/Model/ModelTokensChangedEventBuilder.cs
+++ b/src/TextMateSharp/Model/ModelTokensChangedEventBuilder.cs
@@ -4,38 +4,38 @@ namespace TextMateSharp.Model
 {
     class ModelTokensChangedEventBuilder
     {
-        private ITMModel model;
-        private List<Range> ranges;
+        private ITMModel _model;
+        private List<Range> _ranges;
 
         public ModelTokensChangedEventBuilder(ITMModel model)
         {
-            this.model = model;
-            this.ranges = new List<Range>();
+            this._model = model;
+            this._ranges = new List<Range>();
         }
 
         public void registerChangedTokens(int lineNumber)
         {
-            Range previousRange = ranges.Count == 0 ? null : ranges[ranges.Count - 1];
+            Range previousRange = _ranges.Count == 0 ? null : _ranges[_ranges.Count - 1];
 
-            if (previousRange != null && previousRange.toLineNumber == lineNumber - 1)
+            if (previousRange != null && previousRange.ToLineNumber == lineNumber - 1)
             {
                 // extend previous range
-                previousRange.toLineNumber++;
+                previousRange.ToLineNumber++;
             }
             else
             {
                 // insert new range
-                ranges.Add(new Range(lineNumber));
+                _ranges.Add(new Range(lineNumber));
             }
         }
 
         public ModelTokensChangedEvent Build()
         {
-            if (this.ranges.Count == 0)
+            if (this._ranges.Count == 0)
             {
                 return null;
             }
-            return new ModelTokensChangedEvent(ranges, model);
+            return new ModelTokensChangedEvent(_ranges, _model);
         }
     }
 }

--- a/src/TextMateSharp/Model/Range.cs
+++ b/src/TextMateSharp/Model/Range.cs
@@ -2,13 +2,13 @@ namespace TextMateSharp.Model
 {
     public class Range
     {
-        public int fromLineNumber;
-        public int toLineNumber;
+        public int FromLineNumber { get; private set; }
+        public int ToLineNumber { get; set; }
 
         public Range(int lineNumber)
         {
-            this.fromLineNumber = lineNumber;
-            this.toLineNumber = lineNumber;
+            FromLineNumber = lineNumber;
+            ToLineNumber = lineNumber;
         }
     }
 }

--- a/src/TextMateSharp/Model/TMState.cs
+++ b/src/TextMateSharp/Model/TMState.cs
@@ -4,31 +4,31 @@ namespace TextMateSharp.Model
 {
     public class TMState
     {
-        private TMState parentEmbedderState;
-        private StackElement ruleStack;
+        private TMState _parentEmbedderState;
+        private StackElement _ruleStack;
 
         public TMState(TMState parentEmbedderState, StackElement ruleStatck)
         {
-            this.parentEmbedderState = parentEmbedderState;
-            this.ruleStack = ruleStatck;
+            this._parentEmbedderState = parentEmbedderState;
+            this._ruleStack = ruleStatck;
         }
 
         public void setRuleStack(StackElement ruleStack)
         {
-            this.ruleStack = ruleStack;
+            this._ruleStack = ruleStack;
         }
 
         public StackElement GetRuleStack()
         {
-            return ruleStack;
+            return _ruleStack;
         }
 
         public TMState Clone()
         {
-            TMState parentEmbedderStateClone = this.parentEmbedderState != null ? 
-                this.parentEmbedderState.Clone() : null;
+            TMState parentEmbedderStateClone = this._parentEmbedderState != null ? 
+                this._parentEmbedderState.Clone() : null;
 
-            return new TMState(parentEmbedderStateClone, this.ruleStack);
+            return new TMState(parentEmbedderStateClone, this._ruleStack);
         }
 
         public override bool Equals(object other)
@@ -40,13 +40,13 @@ namespace TextMateSharp.Model
 
             TMState otherState = (TMState)other;
 
-            return Equals(parentEmbedderState, otherState.parentEmbedderState) &&
-                   Equals(ruleStack, otherState.ruleStack);
+            return Equals(_parentEmbedderState, otherState._parentEmbedderState) &&
+                   Equals(_ruleStack, otherState._ruleStack);
         }
 
         public override int GetHashCode()
         {
-            return this.parentEmbedderState.GetHashCode() + this.ruleStack.GetHashCode();
+            return this._parentEmbedderState.GetHashCode() + this._ruleStack.GetHashCode();
         }
 
     }

--- a/src/TextMateSharp/Model/TMToken.cs
+++ b/src/TextMateSharp/Model/TMToken.cs
@@ -4,13 +4,13 @@ namespace TextMateSharp.Model
 {
     public class TMToken
     {
-        public int StartIndex;
+        public int StartIndex { get; private set; }
         public List<string> Scopes { get; private set; }
 
         public TMToken(int startIndex, List<string> scopes)
         {
-            this.StartIndex = startIndex;
-            this.Scopes = scopes;
+            StartIndex = startIndex;
+            Scopes = scopes;
         }
     }
 }

--- a/src/TextMateSharp/Model/TMTokenDecodeData.cs
+++ b/src/TextMateSharp/Model/TMTokenDecodeData.cs
@@ -4,13 +4,13 @@ namespace TextMateSharp.Model
 {
     public class TMTokenDecodeData
     {
-        public string[] scopes;
-        public Dictionary<int, Dictionary<int, bool>> scopeTokensMaps;
+        public string[] Scopes { get; private set; }
+        public Dictionary<int, Dictionary<int, bool>> ScopeTokensMaps { get; private set; }
 
         public TMTokenDecodeData(string[] scopes, Dictionary<int, Dictionary<int, bool>> scopeTokensMaps)
         {
-            this.scopes = scopes;
-            this.scopeTokensMaps = scopeTokensMaps;
+            Scopes = scopes;
+            ScopeTokensMaps = scopeTokensMaps;
         }
     }
 }

--- a/src/TextMateSharp/Model/Tokenizer.cs
+++ b/src/TextMateSharp/Model/Tokenizer.cs
@@ -6,13 +6,13 @@ namespace TextMateSharp.Model
 {
     public class Tokenizer : ITokenizationSupport
     {
-        private IGrammar grammar;
-        private DecodeMap decodeMap;
+        private IGrammar _grammar;
+        private DecodeMap _decodeMap;
 
         public Tokenizer(IGrammar grammar)
         {
-            this.grammar = grammar;
-            this.decodeMap = new DecodeMap();
+            this._grammar = grammar;
+            this._decodeMap = new DecodeMap();
         }
 
         public TMState GetInitialState()
@@ -27,7 +27,7 @@ namespace TextMateSharp.Model
 
         public LineTokens Tokenize(string line, TMState state, int offsetDelta, int maxLen)
         {
-            if (grammar == null)
+            if (_grammar == null)
                 return null;
 
             TMState freshState = state != null ? state.Clone() : GetInitialState();
@@ -35,7 +35,7 @@ namespace TextMateSharp.Model
             if (line.Length > 0 && line.Length > maxLen)
                 line = line.Substring(0, maxLen);
 
-            ITokenizeLineResult textMateResult = grammar.TokenizeLine(line, freshState.GetRuleStack());
+            ITokenizeLineResult textMateResult = _grammar.TokenizeLine(line, freshState.GetRuleStack());
             freshState.setRuleStack(textMateResult.RuleStack);
 
             // Create the result early and fill in the tokens later
@@ -46,7 +46,7 @@ namespace TextMateSharp.Model
             {
                 IToken token = tmResultTokens[tokenIndex];
                 int tokenStartIndex = token.StartIndex;
-                string tokenType = DecodeTextMateToken(this.decodeMap, token.Scopes);
+                string tokenType = DecodeTextMateToken(this._decodeMap, token.Scopes);
 
                 // do not push a new token if the type is exactly the same (also
                 // helps with ligatures)
@@ -62,9 +62,9 @@ namespace TextMateSharp.Model
 
         private string DecodeTextMateToken(DecodeMap decodeMap, List<string> scopes)
         {
-            string[] prevTokenScopes = decodeMap.prevToken.scopes;
+            string[] prevTokenScopes = decodeMap.PrevToken.Scopes;
             int prevTokenScopesLength = prevTokenScopes.Length;
-            Dictionary<int, Dictionary<int, bool>> prevTokenScopeTokensMaps = decodeMap.prevToken.scopeTokensMaps;
+            Dictionary<int, Dictionary<int, bool>> prevTokenScopeTokensMaps = decodeMap.PrevToken.ScopeTokensMaps;
 
             Dictionary<int, Dictionary<int, bool>> scopeTokensMaps = new Dictionary<int, Dictionary<int, bool>>();
             Dictionary<int, bool> prevScopeTokensMaps = new Dictionary<int, bool>();
@@ -93,7 +93,7 @@ namespace TextMateSharp.Model
                 scopeTokensMaps[level] = prevScopeTokensMaps;
             }
 
-            decodeMap.prevToken = new TMTokenDecodeData(scopes.ToArray(), scopeTokensMaps);
+            decodeMap.PrevToken = new TMTokenDecodeData(scopes.ToArray(), scopeTokensMaps);
             return decodeMap.GetToken(prevScopeTokensMaps);
         }
     }

--- a/src/TextMateSharp/Registry/Registry.cs
+++ b/src/TextMateSharp/Registry/Registry.cs
@@ -43,6 +43,8 @@ namespace TextMateSharp.Registry
 
         public IGrammar LoadGrammar(string initialScopeName)
         {
+            if (string.IsNullOrEmpty(initialScopeName))
+                return null;
 
             List<string> remainingScopeNames = new List<string>();
             remainingScopeNames.Add(initialScopeName);

--- a/src/TextMateSharp/Themes/Theme.cs
+++ b/src/TextMateSharp/Themes/Theme.cs
@@ -261,7 +261,7 @@ namespace TextMateSharp.Themes
             // Sort rules lexicographically, and then by index if necessary
             parsedThemeRules.Sort((a, b) =>
             {
-                int r = CompareUtils.Strcmp(a.scope, b.scope);
+                int r = CompareUtils.StrCmp(a.scope, b.scope);
                 if (r != 0)
                 {
                     return r;


### PR DESCRIPTION
- Remove unused code in ORegex.
- Do not start the tokenizer thread in the TMModel if not needed.
- Use Threadpool threads for the TMModel.
- Use standard C# syntax for properties and members across all the sources.