### PR TITLE
Sync create oniguruma regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,7 @@ onigwrap/src/libonigwrap.so
 .idea/.idea.TextMateSharp.dir/.idea/encodings.xml
 .idea/.idea.TextMateSharp.dir/.idea/indexLayout.xml
 .idea/.idea.TextMateSharp.dir/.idea/vcs.xml
+onigwrap/src/onigwrap.lib
+onigwrap/src/onigwrap.exp
+onigwrap/src/onigwrap.dll
+onigwrap/src/onig_s.lib

--- a/src/TextMateSharp/Internal/Oniguruma/ORegex.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/ORegex.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using log4net;
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,6 +8,8 @@ namespace TextMateSharp.Internal.Oniguruma
 {
     public class ORegex : IDisposable
     {
+        private static object _createRegexSync = new object();
+
         private IntPtr _regex;
         private IntPtr _region;
         private bool _disposed = false;
@@ -28,13 +32,16 @@ namespace TextMateSharp.Internal.Oniguruma
             pattern = UnicodeCharEscape.AddBracesToUnicodePatterns(pattern);
             pattern = UnicodeCharEscape.ConstraintUnicodePatternLenght(pattern);
 
-            fixed (char* patternPtr = pattern)
+            lock (_createRegexSync)
             {
-                _regex = OnigInterop.onigwrap_create(
-                    patternPtr,
-                    Encoding.Unicode.GetByteCount(patternPtr, pattern.Length),
-                    ignoreCaseArg,
-                    multilineArg);
+                fixed (char* patternPtr = pattern)
+                {
+                    _regex = OnigInterop.onigwrap_create(
+                        patternPtr,
+                        Encoding.Unicode.GetByteCount(patternPtr, pattern.Length),
+                        ignoreCaseArg,
+                        multilineArg);
+                }
             }
 
             if (!Valid)

--- a/src/TextMateSharp/Internal/Oniguruma/ORegex.cs
+++ b/src/TextMateSharp/Internal/Oniguruma/ORegex.cs
@@ -1,6 +1,4 @@
-﻿using log4net;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 


### PR DESCRIPTION
On some multithreading environments, the app crashes due to a corrupted heap caused by the onig lib:
https://github.com/kkos/oniguruma/issues/249

Syncing the access across threads to `onigwrap_create` seems to fix the issue. We'll lose the ability to compile regexes in parallel but it's not a big issue in terms of perf.