### PR TITLE
Fixed wrong condition in TMModel

### DIFF
--- a/src/TextMateSharp/Model/TMModel.cs
+++ b/src/TextMateSharp/Model/TMModel.cs
@@ -396,7 +396,7 @@ namespace TextMateSharp.Model
 
             var tokenizerThread = this._thread;
 
-            if (tokenizerThread != null || tokenizerThread.IsStopped)
+            if (tokenizerThread == null || tokenizerThread.IsStopped)
                 return;
 
             this.BuildEventWithCallback(eventBuilder =>


### PR DESCRIPTION
This fixes `ForceTokenization` behavior. The condition to check if the tokenizer thread was null was wrong.