### PR TITLE
Fix cpp grammar

### DIFF
--- a/src/TextMateSharp.Grammars/Resources/Grammars/cpp/package.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/cpp/package.json
@@ -74,13 +74,13 @@
       },
       {
         "language": "cpp",
-        "scopeName": "source.cpp.embedded.macro",
-        "path": "./syntaxes/cpp.embedded.macro.tmLanguage.json"
+        "scopeName": "source.cpp",
+        "path": "./syntaxes/cpp.tmLanguage.json"
       },
       {
         "language": "cpp",
-        "scopeName": "source.cpp",
-        "path": "./syntaxes/cpp.tmLanguage.json"
+        "scopeName": "source.cpp.embedded.macro",
+        "path": "./syntaxes/cpp.embedded.macro.tmLanguage.json"
       },
       {
         "scopeName": "source.c.platform",


### PR DESCRIPTION
Put cpp grammar before cpp embedded macro to get the right scope when asking for it.