### PR TITLE
Expose "colors" dictionary

### DIFF
--- a/src/TextMateSharp.Demo/Program.cs
+++ b/src/TextMateSharp.Demo/Program.cs
@@ -94,6 +94,16 @@ namespace TextMateSharp
                     }
                 }
 
+                var colorDictionary = theme.GetGuiColorDictionary();
+                if (colorDictionary is { Count: > 0 })
+                {
+                    Console.WriteLine("Gui Control Colors");
+                    foreach (var kvp in colorDictionary)
+                    {
+                        Console.WriteLine( $"  {kvp.Key}, {kvp.Value}");
+                    }
+                }
+
                 Console.WriteLine("File {0} tokenized in {1}ms.",
                     Path.GetFileName(fileToParse),
                     Environment.TickCount - tokenizeIni);

--- a/src/TextMateSharp.Grammars/Resources/Themes/hc_light.json
+++ b/src/TextMateSharp.Grammars/Resources/Themes/hc_light.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "vscode://schemas/color-theme",
 	"name": "Light High Contrast",
+	"include": "./light_vs.json",
 	"tokenColors": [
 		{
 			"scope": ["meta.embedded", "source.groovy.embedded"],

--- a/src/TextMateSharp.Grammars/Resources/Themes/light_vs.json
+++ b/src/TextMateSharp.Grammars/Resources/Themes/light_vs.json
@@ -36,7 +36,7 @@
 				"string meta.image.inline.markdown"
 			],
 			"settings": {
-				"foreground": "#000000ff"
+				"foreground": "#000000"
 			}
 		},
 		{

--- a/src/TextMateSharp/Internal/Themes/ThemeRaw.cs
+++ b/src/TextMateSharp/Internal/Themes/ThemeRaw.cs
@@ -11,6 +11,7 @@ namespace TextMateSharp.Internal.Themes
         private static string NAME = "name";
         private static string INCLUDE = "include";
         private static string SETTINGS = "settings";
+        private static string COLORS = "colors";
         private static string TOKEN_COLORS = "tokenColors";
         private static string SCOPE = "scope";
         private static string FONT_STYLE = "fontStyle";
@@ -45,6 +46,16 @@ namespace TextMateSharp.Internal.Themes
                 return null;
 
             return result.Cast<IRawThemeSetting>().ToList();
+        }
+
+        public ICollection<KeyValuePair<string,object>> GetGuiColors()
+        {
+            ICollection result = TryGetObject<ICollection>(COLORS);
+
+            if (result == null)
+                return null;
+
+            return result.Cast<KeyValuePair<string,object>>().ToList();
         }
 
         public object GetScope()

--- a/src/TextMateSharp/Themes/IRawTheme.cs
+++ b/src/TextMateSharp/Themes/IRawTheme.cs
@@ -8,5 +8,6 @@ namespace TextMateSharp.Themes
         string GetInclude();
         ICollection<IRawThemeSetting> GetSettings();
         ICollection<IRawThemeSetting> GetTokenColors();
+        ICollection<KeyValuePair<string,object>> GetGuiColors();
     }
 }

--- a/src/TextMateSharp/Themes/Theme.cs
+++ b/src/TextMateSharp/Themes/Theme.cs
@@ -34,7 +34,10 @@ namespace TextMateSharp.Themes
 
             // First get colors from include, then try and overwrite with local colors..
             // I don't see this happening currently, but here just in case that ever happens.
-            ParsedTheme.ParsedGuiColors(themeInclude, guiColorsDictionary);
+            if (themeInclude != null)
+            {
+                ParsedTheme.ParsedGuiColors(themeInclude, guiColorsDictionary);
+            }
             ParsedTheme.ParsedGuiColors(source, guiColorsDictionary);
 
             return new Theme(colorMap, theme, include, guiColorsDictionary);


### PR DESCRIPTION
My ultimate plan with this in Blitz Search is to provide "easy" theme selection.  But I do think that AvaloniaEdit.TextMate should use the editor background to fix what I see as a bug in the AvaloniaEdit demonstration, where some themes don't look like they were meant for a dark background.

Having things like selection highlights and all that come from a place that's already authored will ease up a lot of UI work for me ( color pickers and what-not ).