### PR TITLE
Add mimetypes field to Language

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <SystemTextJsonVersion>7.0.0</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
   </PropertyGroup>
 </Project>

--- a/src/TextMateSharp.Grammars/GrammarDefinition.cs
+++ b/src/TextMateSharp.Grammars/GrammarDefinition.cs
@@ -31,6 +31,10 @@ namespace TextMateSharp.Grammars
         public string ConfigurationFile { get; set; }
         public LanguageConfiguration Configuration {get; set;}
 
+        // May be null
+        [JsonPropertyName("mimetypes")]
+        public List<string> MimeTypes { get; set; }
+
         public override string ToString()
         {
             if (Aliases != null && Aliases.Count > 0)


### PR DESCRIPTION
This adds the `mimetypes` field to the Language definitions. These are present on many of the language configuration files already and allow the user to find the correct grammar based on a mime type.

The project wont build without https://github.com/danipen/TextMateSharp/pull/66. I can rebase after that is merged.

I've tested this locally, but I can add a test if necessary.