### PR TITLE
Emit a ModelTokensChangedEvent for all the lines when setting a null grammar

### DIFF
--- a/src/TextMateSharp/Model/Range.cs
+++ b/src/TextMateSharp/Model/Range.cs
@@ -10,5 +10,11 @@ namespace TextMateSharp.Model
             FromLineNumber = lineNumber;
             ToLineNumber = lineNumber;
         }
+
+        public Range(int fromLineNumber, int toLineNumber)
+        {
+            FromLineNumber = fromLineNumber;
+            ToLineNumber = toLineNumber;
+        }
     }
 }

--- a/src/TextMateSharp/Model/TMModel.cs
+++ b/src/TextMateSharp/Model/TMModel.cs
@@ -291,6 +291,10 @@ namespace TextMateSharp.Model
                     Start();
                     InvalidateLine(0);
                 }
+                else
+                {
+                    Emit(new ModelTokensChangedEvent(new Range(0, _lines.GetNumberOfLines() - 1), this));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #68 

**Issue**
When a null grammar is set after previously setting a grammar with line highlights, some lines remain tokenized.

**Resolution**
To fix this, we now emit a `ModelTokensChangedEvent` to notify the `IModelTokensChangedListener` that the state for all lines has changed. This ensures that all lines are properly updated.

**Changes**
* Emitted `ModelTokensChangedEvent` after setting a null grammar. 
* Added a unit test that covers this scenario.