### PR TITLE
Fix some CA1854 NetAnalyzers suggestions

### DIFF
--- a/src/TextMateSharp/Internal/Grammars/BasicScopeAttributesProvider.cs
+++ b/src/TextMateSharp/Internal/Grammars/BasicScopeAttributesProvider.cs
@@ -123,7 +123,7 @@ namespace TextMateSharp.Internal.Grammars
             }
 
             string scopeName = m.Groups[1].Value;
-            return _embeddedLanguages.ContainsKey(scopeName) ? _embeddedLanguages[scopeName] : 0;
+            return _embeddedLanguages.TryGetValue(scopeName, out int value) ? value : 0;
         }
 
         private static int ToStandardTokenType(string tokenType)

--- a/src/TextMateSharp/Internal/Grammars/Grammar.cs
+++ b/src/TextMateSharp/Internal/Grammars/Grammar.cs
@@ -156,9 +156,9 @@ namespace TextMateSharp.Internal.Grammars
 
         public IRawGrammar GetExternalGrammar(string scopeName, IRawRepository repository)
         {
-            if (this._includedGrammars.ContainsKey(scopeName))
+            if (_includedGrammars.TryGetValue(scopeName, out IRawGrammar value))
             {
-                return this._includedGrammars[scopeName];
+                return value;
             }
             else if (this._grammarRepository != null)
             {

--- a/src/TextMateSharp/Internal/Grammars/SyncRegistry.cs
+++ b/src/TextMateSharp/Internal/Grammars/SyncRegistry.cs
@@ -91,15 +91,15 @@ namespace TextMateSharp.Internal.Grammars
             Dictionary<string, int> tokenTypes,
             BalancedBracketSelectors balancedBracketSelectors)
         {
-            if (!this._grammars.ContainsKey(scopeName))
+            if (!_grammars.TryGetValue(scopeName, out IGrammar value))
             {
                 IRawGrammar rawGrammar = Lookup(scopeName);
                 if (rawGrammar == null)
                 {
                     return null;
                 }
-                this._grammars.Add(scopeName,
-                    new Grammar(
+
+                value = new Grammar(
                         scopeName,
                         rawGrammar,
                         initialLanguage,
@@ -107,9 +107,10 @@ namespace TextMateSharp.Internal.Grammars
                         tokenTypes,
                         balancedBracketSelectors,
                         this,
-                        this));
+                        this);
+                this._grammars.Add(scopeName, value);
             }
-            return this._grammars[scopeName];
+            return value;
         }
 
         private static void CollectIncludedScopes(ICollection<string> result, IRawGrammar grammar)

--- a/src/TextMateSharp/Themes/Theme.cs
+++ b/src/TextMateSharp/Themes/Theme.cs
@@ -322,11 +322,12 @@ namespace TextMateSharp.Themes
         {
             lock (this._cachedMatchRoot)
             {
-                if (!this._cachedMatchRoot.ContainsKey(scopeName))
+                if (!_cachedMatchRoot.TryGetValue(scopeName, out List<ThemeTrieElementRule> value))
                 {
-                    this._cachedMatchRoot[scopeName] = this._root.Match(scopeName);
+                    value = this._root.Match(scopeName);
+                    this._cachedMatchRoot[scopeName] = value;
                 }
-                return this._cachedMatchRoot[scopeName];
+                return value;
             }
         }
 

--- a/src/TextMateSharp/Themes/ThemeTrieElement.cs
+++ b/src/TextMateSharp/Themes/ThemeTrieElement.cs
@@ -94,9 +94,9 @@ namespace TextMateSharp.Themes
                 tail = scope.Substring(dotIndex + 1);
             }
 
-            if (this.children.ContainsKey(head))
+            if (children.TryGetValue(head, out ThemeTrieElement value))
             {
-                return this.children[head].Match(tail);
+                return value.Match(tail);
             }
 
             arr = new List<ThemeTrieElementRule>();
@@ -130,9 +130,9 @@ namespace TextMateSharp.Themes
             }
 
             ThemeTrieElement child;
-            if (this.children.ContainsKey(head))
+            if (children.TryGetValue(head, out ThemeTrieElement value))
             {
-                child = this.children[head];
+                child = value;
             }
             else
             {


### PR DESCRIPTION
Use Dictionary.TryGetValue rather than ContainsKey followed by an element access.

Refs 
![image](https://github.com/user-attachments/assets/9866629c-9b80-4317-babf-26cf8d326902)

and https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1854


