### PR TITLE
lock listeners

### DIFF
--- a/src/TextMateSharp/Model/TMModel.cs
+++ b/src/TextMateSharp/Model/TMModel.cs
@@ -327,7 +327,11 @@ namespace TextMateSharp.Model
 
         public void Dispose()
         {
-            listeners.Clear();
+            lock (listeners)
+            {
+                listeners.Clear();
+            }
+
             Stop();
             GetLines().Dispose();
         }
@@ -375,15 +379,18 @@ namespace TextMateSharp.Model
 
         private void Emit(ModelTokensChangedEvent e)
         {
-            foreach (IModelTokensChangedListener listener in listeners)
+            lock (listeners)
             {
-                try
+                foreach (IModelTokensChangedListener listener in listeners)
                 {
-                    listener.ModelTokensChanged(e);
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine(ex.Message);
+                    try
+                    {
+                        listener.ModelTokensChanged(e);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine(ex.Message);
+                    }
                 }
             }
         }


### PR DESCRIPTION

There is a problem with listeners becoming an exception during iteration.
This has been fixed in this pull request.

```
System.InvalidOperationException: InvalidOperation_EnumFailedVersion
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at TextMateSharp.Model.TMModel.Emit(ModelTokensChangedEvent e) in /_/src/TextMateSharp/Model/TMModel.cs:line 378
   at TextMateSharp.Model.TMModel.BuildEventWithCallback(Action`1 callback) in /_/src/TextMateSharp/Model/TMModel.cs:line 372
   at TextMateSharp.Model.TMModel.TokenizerThread.RevalidateTokens(Int32 startLine, Nullable`1 toLineIndexOrNull) in /_/src/TextMateSharp/Model/TMModel.cs:line 120
   at TextMateSharp.Model.TMModel.TokenizerThread.ThreadWorker(Object state) in /_/src/TextMateSharp/Model/TMModel.cs:line 101
```