### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/TextMateSharp/Model/TMModel.cs
+++ b/src/TextMateSharp/Model/TMModel.cs
@@ -430,7 +430,11 @@ namespace TextMateSharp.Model
 
         public void InvalidateLine(int lineIndex)
         {
-            this._lines.Get(lineIndex).IsInvalid = true;
+            var line = this._lines.Get(lineIndex);
+            if (line == null)
+                return;
+
+            line.IsInvalid = true;
 
             lock (_lock)
             {


### PR DESCRIPTION
This was sometimes an exception when using TextMateSharp, and this problem has been corrected.

```
System.NullReferenceException: Arg_NullReferenceException
at TextMateSharp.Model.TMModel.InvalidateLine(Int32 lineIndex) in /_/src/TextMateSharp/Model/TMModel.cs:line 433
at TextMateSharp.Model.TMModel.TokenizerThread.ThreadWorker(Object state) in /_/src/TextMateSharp/Model/TMModel.cs:line 109
at System.Threading.QueueUserWorkItemCallback.Execute()
at System.Threading.ThreadPoolWorkQueue.Dispatch()
at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```






