### PR TITLE
Add LanguageConfiguration.SurroundingPairs

### DIFF
--- a/src/TextMateSharp.Grammars.Tests/GrammarTests.cs
+++ b/src/TextMateSharp.Grammars.Tests/GrammarTests.cs
@@ -127,6 +127,20 @@ namespace TextMateSharp.Grammars.Tests
         }
 
         [Test]
+        public void Assert_Language_Configuration_Has_Surrounding_Pairs()
+        {
+            RegistryOptions options = new RegistryOptions(ThemeName.Light);
+
+            var surroundingPairs = options.GetLanguageByExtension(".cs").Configuration.SurroundingPairs;
+            Assert.IsNotEmpty(surroundingPairs);
+            Assert.IsTrue(surroundingPairs.Any(pair => pair[0] == '(' && pair[1] == ')'));
+
+            surroundingPairs = options.GetLanguageByExtension(".html").Configuration.SurroundingPairs;
+            Assert.IsNotEmpty(surroundingPairs);
+            Assert.IsTrue(surroundingPairs.Any(pair => pair[0] == '<' && pair[1] == '>'));
+        }
+
+        [Test]
         public void Assert_Every_Grammar_With_Snippets_Can_Load_Snippets()
         {
             RegistryOptions options = new RegistryOptions(ThemeName.Light);

--- a/src/TextMateSharp.Grammars/LanguageConfiguration.cs
+++ b/src/TextMateSharp.Grammars/LanguageConfiguration.cs
@@ -356,7 +356,7 @@ namespace TextMateSharp.Grammars
                             }
 
                             if (open != null && close != null) 
-                                surroundingPairs.Add([open.First(), close.First()]);
+                                surroundingPairs.Add(new char[] { open.First(), close.First() });
 
                             break;
                     }


### PR DESCRIPTION
I am working on a text editor based on AvaloniaEdit and saw the TextMateSharp does not load the [`surroundingPairs`](https://code.visualstudio.com/api/language-extensions/language-configuration-guide#autosurrounding) from `language-configuration.json`.

This PR adds the `SurroundingPairs` to the `LanguageConfiguration`.
