### PR TITLE
Update onigwrap to 1.0.11

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -3,6 +3,6 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
-    <OnigwrapVersion>1.0.10</OnigwrapVersion>
+    <OnigwrapVersion>1.0.11</OnigwrapVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updated onigwrap to 1.0.11 to fix issue when compiling on MacOS against x86.

Fixes #126 