### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a .NET class library project (TextMateSharp) — no external services, databases, or Docker required.
+
+### Prerequisites
+- .NET 8.0 SDK (test/demo/benchmark projects target `net8.0`; core libraries target `netstandard2.0`)
+
+### Key commands
+| Action | Command | Notes |
+|---|---|---|
+| Restore | `dotnet restore` | From repo root |
+| Build | `dotnet build` | Builds all 6 projects in `TextMateSharp.sln` |
+| Test | `dotnet test` | Runs NUnit tests in `TextMateSharp.Tests` and `TextMateSharp.Grammars.Tests` (726 tests) |
+| Demo | `cd src/TextMateSharp.Demo && dotnet run -- ./testdata/samplefiles/sample.cs` | Syntax-highlights a sample C# file |
+| Benchmark | `cd src/TextMateSharp.Benchmarks && dotnet run -c Release` | BenchmarkDotNet performance tests |
+
+### Non-obvious notes
+- The CI workflow (`.github/workflows/dotnet.yml`) installs .NET 6.0.x, but `net8.0` is the actual TFM for test/demo/benchmark projects. You need .NET 8.0 SDK.
+- The `Onigwrap` native library version is pinned in `build/Directory.Build.props`. If builds fail with native-interop errors, check that file.
+- No linter is configured (no `.editorconfig` enforcement, no `dotnet format` CI step). Code style is not enforced via tooling.
+- Sample test data files for the demo app are in `src/TextMateSharp.Demo/testdata/samplefiles/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working on this codebase.

## What's included

- Prerequisites (.NET 8.0 SDK requirement)
- Key commands table (restore, build, test, demo, benchmark)
- Non-obvious notes (CI uses .NET 6 but projects target net8.0, Onigwrap native version pinning, no linter configured)

## Environment verification

All setup steps were verified:

- **Build**: `dotnet build` — 0 warnings, 0 errors across all 6 projects
- **Tests**: `dotnet test` — 726/726 passed
- **Demo**: `dotnet run` on `TextMateSharp.Demo` — successfully syntax-highlighted sample C# code

Test output:
[test_output.log](https://cursor.com/agents/bc-848cf375-3964-4764-933e-a84e5c6db826/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)

Demo output:
[demo_output.log](https://cursor.com/agents/bc-848cf375-3964-4764-933e-a84e5c6db826/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-848cf375-3964-4764-933e-a84e5c6db826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-848cf375-3964-4764-933e-a84e5c6db826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

