### PR TITLE
Add x86 assembly grammar

### DIFF
--- a/src/TextMateSharp.Grammars.Tests/GrammarTests.cs
+++ b/src/TextMateSharp.Grammars.Tests/GrammarTests.cs
@@ -12,7 +12,7 @@ namespace TextMateSharp.Grammars.Tests
         {
             RegistryOptions options = new RegistryOptions(ThemeName.Light);
 
-            Assert.That(options.GetAvailableLanguages().Count, Is.EqualTo(63));
+            Assert.That(options.GetAvailableLanguages().Count, Is.EqualTo(64));
         }
 
         [Test]

--- a/src/TextMateSharp.Grammars/GrammarNames.cs
+++ b/src/TextMateSharp.Grammars/GrammarNames.cs
@@ -51,6 +51,7 @@
             "TypescriptBasics",
             "Typst",
             "VB",
+            "x86Asm",
             "XML",
             "YAML"
         };

--- a/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/cgmanifest.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/cgmanifest.json
@@ -1,0 +1,17 @@
+{
+	"registrations": [
+		{
+			"component": {
+				"type": "git",
+				"git": {
+					"name": "Universal-Assembly-Syntax-Highlighting",
+					"repositoryUrl": "https://github.com/haxo-games/Universal-Assembly-Syntax-Highlighting"
+				}
+			},
+			"license": "MIT",
+			"description": "The files syntaxes/x86asm.tmLanguage.json were derived from asm.tmLanguage.json in https://github.com/haxo-games/Universal-Assembly-Syntax-Highlighting.",
+			"version": "1.0.0"
+		}
+	],
+	"version": 1
+}

--- a/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/language-configuration.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/language-configuration.json
@@ -1,0 +1,22 @@
+{
+	"comments": {
+		"lineComment": ";"
+	},
+	"brackets": [
+		["[", "]"]
+	],
+	"autoClosingPairs": [
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "'",
+			"close": "'"
+		}
+	],
+	"surroundingPairs": [
+		["[", "]"],
+		["'", "'"]
+	]
+}

--- a/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/package.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "x86asm",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "1.0.0",
+  "publisher": "RysteQ",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.20.0"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "x86asm",
+        "aliases": [
+          "x86 Assembly",
+          "x86",
+          "Assembly"
+        ],
+        "extensions": [
+          ".asm"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "x86asm",
+        "scopeName": "source.x86asm",
+        "path": "./syntaxes/x86asm.tmLanguage.json"
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/vscode.git"
+  }
+}

--- a/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/package.nls.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "x86 Assembly",
+	"description": "Provides syntax highlighting for the original x86 assembly ISA."
+}

--- a/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/syntaxes/x86asm.tmLanguage.json
+++ b/src/TextMateSharp.Grammars/Resources/Grammars/x86asm/syntaxes/x86asm.tmLanguage.json
@@ -1,0 +1,372 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "x86/x64/ARM Assembly",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#constants" },
+    { "include": "#registers" },
+    { "include": "#instructions" },
+    { "include": "#directives" },
+    { "include": "#data_labels" },
+    { "include": "#labels" },
+    { "include": "#sections" },
+    { "include": "#memory_operands" },
+    { "include": "#operators" },
+    { "include": "#symbols" },
+    { "include": "#functions" },
+    { "include": "#structure" },
+    { "include": "#macros" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.semicolon.x86asm",
+          "match": ";.*$"
+        },
+        {
+          "name": "comment.block.x86asm",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "name": "keyword.control.directive.define.x86asm",
+          "match": "%define\\b"
+        },
+        {
+          "name": "keyword.control.directive.assign.x86asm",
+          "match": "%assign\\b"
+        },
+        {
+          "name": "keyword.control.directive.equ.x86asm",
+          "match": "\\bequ\\b"
+        },
+        {
+          "name": "keyword.control.directive.nasm.x86asm",
+          "match": "%(if|ifdef|ifndef|else|elif|endif|include|macro|endmacro|rep|endrep|exitrep|rotate|push|pop|local|undef|strlen|substr|arg|stacksize|use16|use32|use64)\\b"
+        },
+        {
+          "name": "keyword.control.directive.x86asm",
+          "match": "\\.(file|cfi_[a-zA-Z_]+|gcc_except_table|ctors|ascii|lcomm|byte|ident|align|rdata|rodata|comment|tbss|init|fini|note|debug|intel_syntax)\\b"
+        },
+        {
+          "name": "keyword.control.directive.offset.x86asm",
+          "match": "\\bOFFSET\\b"
+        },
+        {
+          "name": "keyword.control.directive.uleb128.x86asm",
+          "match": "\\.uleb128\\b"
+        },
+        {
+          "name": "keyword.control.directive.def.x86asm",
+          "match": "\\.def\\b"
+        },
+        {
+          "name": "keyword.control.directive.long.x86asm",
+          "match": "\\.long\\b"
+        },
+        {
+          "name": "keyword.control.directive.scl.x86asm",
+          "match": "\\.scl\\b"
+        },
+        {
+          "name": "keyword.control.directive.type.x86asm",
+          "match": "\\.type\\b"
+        },
+        {
+          "name": "keyword.control.directive.endef.x86asm",
+          "match": "\\.endef\\b"
+        },
+        {
+          "name": "keyword.control.directive.globl.x86asm",
+          "match": "\\.globl\\b"
+        },
+        {
+          "name": "keyword.control.directive.space.x86asm",
+          "match": "\\.space\\b"
+        },
+        {
+          "name": "keyword.control.directive.intel_syntax.x86asm",
+          "match": "\\.intel_syntax\\b"
+        },
+        {
+          "name": "keyword.control.directive.extern.x86asm",
+          "match": "\\bextern\\b"
+        },
+        {
+          "name": "keyword.control.directive.global.x86asm",
+          "match": "\\bglobal\\b"
+        },
+        {
+          "name": "keyword.control.directive.weak.x86asm",
+          "match": "\\.weak\\b"
+        },
+        {
+          "name": "keyword.control.directive.hidden.x86asm",
+          "match": "\\.hidden\\b"
+        },
+        {
+          "name": "keyword.control.directive.protected.x86asm",
+          "match": "\\.protected\\b"
+        },
+        {
+          "name": "keyword.control.directive.internal.x86asm",
+          "match": "\\.internal\\b"
+        },
+        {
+          "name": "keyword.control.directive.default.x86asm",
+          "match": "\\bdefault\\b"
+        },
+        {
+          "name": "keyword.control.directive.rel.x86asm",
+          "match": "\\brel\\b"
+        }
+      ]
+    },
+    "data_labels": {
+      "patterns": [
+        {
+          "name": "markup.deleted.data.label.x86asm",
+          "match": "^\\s*([a-zA-Z_][a-zA-Z0-9_]*):(?=\\s*(resb|resw|resd|resq|db|dw|dd|dq|times))"
+        },
+        {
+          "name": "markup.deleted.data.label.x86asm",
+          "match": "\\b(list\\d*\\w*|\\w*Size|\\w*size)\\b"
+        }
+      ]
+    },
+    "labels": {
+      "patterns": [
+        {
+          "name": "entity.name.function.label.x86asm",
+          "match": "^\\s*\\.[a-zA-Z_][a-zA-Z0-9_]*:"
+        },
+        {
+          "name": "entity.name.function.label.x86asm",
+          "match": "^\\s*[a-zA-Z_][a-zA-Z0-9_]*:"
+        },
+        {
+          "name": "entity.name.tag.label.x86asm",
+          "match": "^\\s*L[a-zA-Z0-9_]+:"
+        }
+      ]
+    },
+    "sections": {
+      "patterns": [
+        {
+          "name": "keyword.control.section.x86asm",
+          "match": "\\.(section .(text|data|bss|tbss|tcomm))\\b"
+        },
+        {
+          "name": "keyword.control.section.x86asm",
+          "match": "\\.(text|data|bss|tbss|tcomm|rodata)\\b"
+        }
+      ]
+    },
+    "instructions": {
+      "patterns": [
+        {
+          "name": "keyword.control.instruction.x86asm",
+          "match": "\\b(?i)(mov|push|pop|call|ret|leave|jmp|je|jne|jz|jnz|jbe|jae|ja|jb|jge|jg|jl|jle|jo|jno|js|jns|jc|jnc|jp|jnp|add|sub|mul|div|imul|idiv|and|or|xor|xchg|lea|cmp|test|inc|dec|shl|shr|sal|sar|rol|ror|rcl|rcr|movzx|movsx|movsxd|nop|enter|int|syscall|sysret|hlt|in|out|rdmsr|wrmsr|cbw|cwd|cdq|cqo|rep|repe|repz|repne|repnz|loop|loope|loopz|loopne|loopnz|clc|stc|cli|sti|cld|std|lahf|sahf|pushf|popf|pusha|popa|pushad|popad)\\b"
+        },
+        {
+          "name": "keyword.control.instruction.sse.x86asm",
+          "match": "\\b(?i)(movq|movd|movdqa|movdqu|movaps|movups|movapd|movupd|movss|movsd|movhps|movlps|movhpd|movlpd|xorps|xorpd|andps|andpd|orps|orpd|addps|addpd|addss|addsd|subps|subpd|subss|subsd|mulps|mulpd|mulss|mulsd|divps|divpd|divss|divsd|maxps|maxpd|maxss|maxsd|minps|minpd|minss|minsd|cmpps|cmppd|cmpss|cmpsd|comiss|comisd|ucomiss|ucomisd|cvtps2pd|cvtpd2ps|cvtps2dq|cvtpd2dq|cvtdq2ps|cvtdq2pd|cvtss2sd|cvtsd2ss|cvtss2si|cvtsd2si|cvttss2si|cvttsd2si|cvtsi2ss|cvtsi2sd)\\b"
+        },
+        {
+          "name": "keyword.control.instruction.avx.x86asm",
+          "match": "\\b(?i)(vzeroupper|vzeroall|vmovdqa|vmovdqu|vmovaps|vmovups|vmovapd|vmovupd|vaddps|vaddpd|vaddss|vaddsd|vsubps|vsubpd|vsubss|vsubsd|vmulps|vmulpd|vmulss|vmulsd|vdivps|vdivpd|vdivss|vdivsd|vxorps|vxorpd|vandps|vandpd|vorps|vorpd|vcmpps|vcmppd|vcmpss|vcmpsd|vbroadcastss|vbroadcastsd|vinsertf128|vextractf128|vperm2f128|vblendps|vblendpd|vshufps|vshufpd)\\b"
+        }
+      ]
+    },
+    "registers": {
+      "patterns": [
+        {
+          "name": "variable.language.register.simd.x86asm",
+          "match": "\\b(?i)(xmm(?:[0-9]|1[0-5])|ymm(?:[0-9]|[12][0-9]|3[01])|zmm(?:[0-9]|[12][0-9]|3[01]))\\b"
+        },
+        {
+          "name": "variable.language.register.mask.x86asm",
+          "match": "\\b(?i)k[0-7]\\b"
+        },
+        {
+          "name": "variable.language.register.tile.x86asm",
+          "match": "\\b(?i)tmm[0-7]\\b"
+        },
+        {
+          "name": "variable.language.register.x86asm",
+          "match": "\\b(?i)(rax|rbx|rcx|rdx|rsi|rdi|rbp|rsp|r8|r9|r10|r11|r12|r13|r14|r15|eax|ebx|ecx|edx|esi|edi|ebp|esp|ax|bx|cx|dx|si|di|bp|sp|al|bl|cl|dl|spl|bpl|sil|dil|ah|bh|ch|dh|eip|rip|eflags|rflags|cr[0-4]|dr[0-7]|tr[3-6]|cs|ds|ss|es|fs|gs)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.x86asm",
+          "match": "\\b(0x[0-9A-Fa-f]+)\\b"
+        },
+        {
+          "name": "constant.numeric.decimal.x86asm",
+          "match": "\\b([0-9]+)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.x86asm",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.x86asm",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.x86asm",
+          "match": "'([^'\\\\]|\\\\.)*'"
+        },
+        {
+          "name": "string.quoted.single.x86asm",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.x86asm",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "memory_operands": {
+      "patterns": [
+        {
+          "name": "support.type.memory.size.x86asm",
+          "match": "\\b(BYTE|WORD|DWORD|QWORD|XMMWORD|YMMWORD|ZMMWORD)\\s+PTR\\b"
+        },
+        {
+          "name": "support.type.memory.size.x86asm",
+          "match": "\\b(TBYTE|TWORD|DQWORD|OWORD|FWORD)\\b"
+        },
+        {
+          "name": "support.type.memory.size.x86asm",
+          "match": "\\b(byte|word|dword|qword|xmmword|ymmword|zmmword|tbyte|tword|dqword|oword|fword)\\b"
+        },
+        {
+          "name": "punctuation.definition.bracket.square.begin.x86asm",
+          "match": "\\[",
+          "push": [
+            {
+              "name": "punctuation.definition.bracket.square.end.x86asm",
+              "match": "\\]",
+              "pop": true
+            },
+            { "include": "#registers" },
+            { "include": "#operators" },
+            { "include": "#constants" },
+            {
+              "name": "entity.name.memory_operand.inside_brackets.x86asm",
+              "match": "[^\\]]+"
+            }
+          ]
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arithmetic.x86asm",
+          "match": "[+\\-*/%]"
+        },
+        {
+          "name": "keyword.operator.logical.x86asm",
+          "match": "[&|^~]"
+        },
+        {
+          "name": "keyword.operator.comparison.x86asm",
+          "match": "[<>=!]"
+        },
+        {
+          "name": "punctuation.separator.comma.x86asm",
+          "match": ","
+        }
+      ]
+    },
+    "symbols": {
+      "patterns": [
+        {
+          "name": "entity.name.function.x86asm",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*|__[a-zA-Z0-9_]+)\\b"
+        },
+        {
+          "name": "entity.name.label.x86asm",
+          "match": "\\b(L[a-zA-Z0-9_]+|FLAT:[a-zA-Z_][a-zA-Z0-9_]*)\\b"
+        }
+      ]
+    },
+    "structure": {
+      "patterns": [
+        {
+          "name": "entity.name.structure.x86asm",
+          "match": "\\bSTRUC\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+        },
+        {
+          "name": "variable.parameter.structure_member.x86asm",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s+OFFSET\\s*\\b"
+        },
+        {
+          "name": "constant.numeric.size.x86asm",
+          "match": "\\b([0-9]+)\\s*:\\s*([0-9]+)\\b"
+        }
+      ]
+    },
+    "directive_definitions": {
+      "patterns": [
+        {
+          "name": "keyword.control.directive.def.x86asm",
+          "begin": "\\.def\\s+",
+          "end": ";",
+          "patterns": [
+            {
+              "name": "entity.name.function.x86asm",
+              "match": "([a-zA-Z_][a-zA-Z0-9_]*)"
+            },
+            {
+              "name": "keyword.control.directive.scl.x86asm",
+              "match": "\\.scl\\s+([0-9]+)"
+            },
+            {
+              "name": "keyword.control.directive.type.x86asm",
+              "match": "\\.type\\s+([0-9]+)"
+            },
+            {
+              "name": "keyword.control.directive.endef.x86asm",
+              "match": "\\.endef"
+            }
+          ]
+        }
+      ]
+    },
+    "macros": {
+      "patterns": [
+        {
+          "name": "keyword.control.macro.x86asm",
+          "match": "\\b(macro|endm)\\b"
+        },
+        {
+          "name": "entity.name.macro.x86asm",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s+macro\\b"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.x86asm"
+}


### PR DESCRIPTION
Added x86 grammar support based on the [following work by kapitche ](https://github.com/haxo-games/Universal-Assembly-Syntax-Highlighting).

The tests are all passing on my side and I did run the demo on some sample code and it looks like it is working. If I missed anything, especially inside the `cgmanifest.json` file, please do tell me.