### PR TITLE
Update CI workflows to use .NET 8 SDK

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build netstandard2.0 libraries

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,13 +21,13 @@ jobs:
       run: echo "branch=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
       id: extract_branch
 
-    - name: Restore dependencies
-      run: dotnet restore $SOLUTION
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore $SOLUTION
 
     - name: Build
       run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:Version=${{steps.extract_branch.outputs.branch}} --no-restore


### PR DESCRIPTION
## Summary
- update the main .NET workflow to install the .NET 8 SDK
- update the NuGet publish workflow to install .NET before restore
- align CI SDK setup with the test, demo, and benchmark projects targeting net8.0

## Testing
- git diff --check